### PR TITLE
[WIP] Add Support for PodBuilder

### DIFF
--- a/PodBuilderInfo.json
+++ b/PodBuilderInfo.json
@@ -1,7 +1,6 @@
 {
     "AFNetworking": {
-        "podbuilder_name": "AFNetworking",
-        "framework_path": "Rome/AFNetworking.framework",
+        "framework_path": "Frameworks/Rome/AFNetworking.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/AFNetworking.git",
@@ -13,7 +12,8 @@
                 "AFNetworking/Security",
                 "AFNetworking/Serialization",
                 "AFNetworking/UIKit"
-            ]
+            ],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
@@ -26,65 +26,100 @@
                 "AFNetworking/Serialization",
                 "AFNetworking/Security",
                 "AFNetworking/Reachability"
-            ]
+            ],
+            "is_static": false
         }
     },
     "AGWindowView": {
-        "podbuilder_name": "AGWindowView",
-        "framework_path": "Rome/AGWindowView.framework",
+        "framework_path": "Frameworks/Rome/AGWindowView.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/AGWindowView.git",
                 "hash": "cef7821"
             },
-            "specs": ["AGWindowView"]
+            "specs": ["AGWindowView"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/AGWindowView.git",
                 "hash": "cef7821"
             },
-            "specs": ["AGWindowView"]
+            "specs": ["AGWindowView"],
+            "is_static": false
         }
     },
     "ATInternet-Apple-SDK": {
-        "podbuilder_name": "ATInternet-Apple-SDK",
-        "framework_path": "Rome/Tracker.framework",
+        "framework_path": "Frameworks/Rome/Tracker.framework",
         "restore_info": {
             "version": {
                 "tag": "2.9.3"
             },
-            "specs": ["ATInternet-Apple-SDK/Tracker"]
+            "specs": ["ATInternet-Apple-SDK/Tracker"],
+            "is_static": true,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
             "version": {
                 "tag": "2.9.3"
             },
-            "specs": ["ATInternet-Apple-SDK/Tracker"]
+            "specs": ["ATInternet-Apple-SDK/Tracker"],
+            "is_static": true
+        }
+    },
+    "Appboy-iOS-SDK": {
+        "framework_path": "Frameworks/Rome/Appboy_iOS_SDK.framework",
+        "restore_info": {
+            "version": {
+                "tag": "3.7.1"
+            },
+            "specs": [
+                "Appboy-iOS-SDK",
+                "Appboy-iOS-SDK/Core",
+                "Appboy-iOS-SDK/Feedback",
+                "Appboy-iOS-SDK/InAppMessage",
+                "Appboy-iOS-SDK/NewsFeed",
+                "Appboy-iOS-SDK/UI"
+            ],
+            "is_static": false
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "3.7.1"
+            },
+            "specs": [
+                "Appboy-iOS-SDK",
+                "Appboy-iOS-SDK/UI",
+                "Appboy-iOS-SDK/NewsFeed",
+                "Appboy-iOS-SDK/Feedback",
+                "Appboy-iOS-SDK/InAppMessage",
+                "Appboy-iOS-SDK/Core"
+            ],
+            "is_static": false
         }
     },
     "BPForms": {
-        "podbuilder_name": "BPForms",
-        "framework_path": "Rome/BPForms.framework",
+        "framework_path": "Frameworks/Rome/BPForms.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/BPForms.git",
                 "hash": "17465e9"
             },
-            "specs": ["BPForms/Core"]
+            "specs": ["BPForms/Core"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/BPForms.git",
                 "hash": "17465e9"
             },
-            "specs": ["BPForms/Core"]
+            "specs": ["BPForms/Core"],
+            "is_static": false
         }
     },
     "BlocksKit": {
-        "podbuilder_name": "BlocksKit",
-        "framework_path": "Rome/BlocksKit.framework",
+        "framework_path": "Frameworks/Rome/BlocksKit.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/BlocksKit.git",
@@ -98,7 +133,8 @@
                 "BlocksKit/MessageUI",
                 "BlocksKit/QuickLook",
                 "BlocksKit/UIKit"
-            ]
+            ],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
@@ -113,50 +149,54 @@
                 "BlocksKit/MessageUI",
                 "BlocksKit/QuickLook",
                 "BlocksKit/UIKit"
-            ]
+            ],
+            "is_static": false
         }
     },
     "Bolts": {
-        "podbuilder_name": "Bolts",
-        "framework_path": "Rome/Bolts.framework",
+        "framework_path": "Frameworks/Rome/Bolts.framework",
         "restore_info": {
             "version": {
                 "tag": "1.9.0"
             },
-            "specs": ["Bolts", "Bolts/AppLinks", "Bolts/Tasks"]
+            "specs": ["Bolts", "Bolts/AppLinks", "Bolts/Tasks"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.9.0"
             },
-            "specs": ["Bolts", "Bolts/AppLinks", "Bolts/Tasks"]
+            "specs": ["Bolts", "Bolts/AppLinks", "Bolts/Tasks"],
+            "is_static": false
         }
     },
     "CocoaAsyncSocket": {
-        "podbuilder_name": "CocoaAsyncSocket",
-        "framework_path": "Rome/CocoaAsyncSocket.framework",
+        "framework_path": "Frameworks/Rome/CocoaAsyncSocket.framework",
         "restore_info": {
             "version": {
                 "tag": "7.5.1"
             },
-            "specs": ["CocoaAsyncSocket", "CocoaAsyncSocket/GCD"]
+            "specs": ["CocoaAsyncSocket", "CocoaAsyncSocket/GCD"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "7.5.1"
             },
-            "specs": ["CocoaAsyncSocket", "CocoaAsyncSocket/GCD"]
+            "specs": ["CocoaAsyncSocket", "CocoaAsyncSocket/GCD"],
+            "is_static": false
         }
     },
     "DeepLinkParser": {
-        "podbuilder_name": "DeepLinkParser",
-        "framework_path": "Rome/DeepLinkParser.framework",
+        "framework_path": "Frameworks/Rome/DeepLinkParser.framework",
         "restore_info": {
             "version": {
                 "repo": "ssh://git@bitbucket.some_username.apa.net:7999/mob/deeplinkparser_swift.git",
                 "tag": "1.1.4"
             },
-            "specs": ["DeepLinkParser"]
+            "specs": ["DeepLinkParser"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
@@ -164,381 +204,461 @@
                 "repo": "ssh://git@bitbucket.some_username.apa.net:7999/mob/deeplinkparser_swift.git",
                 "tag": "1.1.4"
             },
-            "specs": ["DeepLinkParser"]
+            "specs": ["DeepLinkParser"],
+            "is_static": false
         }
     },
     "FBSDKCoreKit": {
-        "podbuilder_name": "FBSDKCoreKit",
-        "framework_path": "Rome/FBSDKCoreKit.framework",
+        "framework_path": "Frameworks/Rome/FBSDKCoreKit.framework",
         "restore_info": {
             "version": {
                 "tag": "4.35.0"
             },
-            "specs": ["FBSDKCoreKit"]
+            "specs": ["FBSDKCoreKit"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "4.35.0"
             },
-            "specs": ["FBSDKCoreKit"]
+            "specs": ["FBSDKCoreKit"],
+            "is_static": false
         }
     },
     "FBSDKShareKit": {
-        "podbuilder_name": "FBSDKShareKit",
-        "framework_path": "Rome/FBSDKShareKit.framework",
+        "framework_path": "Frameworks/Rome/FBSDKShareKit.framework",
         "restore_info": {
             "version": {
                 "tag": "4.35.0"
             },
-            "specs": ["FBSDKShareKit"]
+            "specs": ["FBSDKShareKit"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "4.35.0"
             },
-            "specs": ["FBSDKShareKit"]
+            "specs": ["FBSDKShareKit"],
+            "is_static": false
+        }
+    },
+    "FLAnimatedImage": {
+        "framework_path": "Frameworks/Rome/FLAnimatedImage.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.0.12"
+            },
+            "specs": ["FLAnimatedImage"],
+            "is_static": false
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.0.12"
+            },
+            "specs": ["FLAnimatedImage"],
+            "is_static": false
         }
     },
     "FLEX": {
-        "podbuilder_name": "FLEX",
-        "framework_path": "Rome/FLEX.framework",
+        "framework_path": "Frameworks/Rome/FLEX.framework",
         "restore_info": {
             "version": {
                 "tag": "1.1.1"
             },
-            "specs": ["FLEX"]
+            "specs": ["FLEX"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.1.1"
             },
-            "specs": ["FLEX"]
+            "specs": ["FLEX"],
+            "is_static": false
         }
     },
     "HighlanderFoundationKit": {
-        "podbuilder_name": "HighlanderFoundationKit",
-        "framework_path": "Rome/HighlanderFoundationKit.framework",
+        "framework_path": "Frameworks/Rome/HighlanderFoundationKit.framework",
         "restore_info": {
             "version": {
                 "tag": "8.0.2"
             },
-            "specs": ["HighlanderFoundationKit/Core"]
+            "specs": ["HighlanderFoundationKit/Core"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
             "version": {
                 "tag": "8.0.2"
             },
-            "specs": ["HighlanderFoundationKit/Core"]
+            "specs": ["HighlanderFoundationKit/Core"],
+            "is_static": false
         }
     },
     "KissXML": {
-        "podbuilder_name": "KissXML",
-        "framework_path": "Rome/KissXML.framework",
+        "framework_path": "Frameworks/Rome/KissXML.framework",
         "restore_info": {
             "version": {
                 "tag": "5.2.3"
             },
-            "specs": ["KissXML"]
+            "specs": ["KissXML"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "5.2.3"
             },
-            "specs": ["KissXML"]
+            "specs": ["KissXML"],
+            "is_static": false
         }
     },
     "Kiwi": {
-        "podbuilder_name": "Kiwi",
-        "framework_path": "Rome/Kiwi.framework",
+        "framework_path": "Frameworks/Rome/Kiwi.framework",
         "restore_info": {
             "version": {
                 "tag": "3.0.0"
             },
-            "specs": ["Kiwi"]
+            "specs": ["Kiwi"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "3.0.0"
             },
-            "specs": ["Kiwi"]
+            "specs": ["Kiwi"],
+            "is_static": false
         }
     },
     "Knocker": {
-        "podbuilder_name": "Knocker",
-        "framework_path": "Rome/Knocker.framework",
+        "framework_path": "Frameworks/Rome/Knocker.framework",
         "restore_info": {
             "version": {
                 "tag": "5.2.0"
             },
-            "specs": ["Knocker"]
+            "specs": ["Knocker"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
             "version": {
                 "tag": "5.2.0"
             },
-            "specs": ["Knocker"]
+            "specs": ["Knocker"],
+            "is_static": false
         }
     },
     "Mantle": {
-        "podbuilder_name": "Mantle",
-        "framework_path": "Rome/Mantle.framework",
+        "framework_path": "Frameworks/Rome/Mantle.framework",
         "restore_info": {
             "version": {
                 "tag": "2.1.0"
             },
-            "specs": ["Mantle", "Mantle/extobjc"]
+            "specs": ["Mantle", "Mantle/extobjc"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "2.1.0"
             },
-            "specs": ["Mantle", "Mantle/extobjc"]
+            "specs": ["Mantle", "Mantle/extobjc"],
+            "is_static": false
         }
     },
     "Masonry": {
-        "podbuilder_name": "Masonry",
-        "framework_path": "Rome/Masonry.framework",
+        "framework_path": "Frameworks/Rome/Masonry.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/Masonry.git",
                 "hash": "02e53e5"
             },
-            "specs": ["Masonry"]
+            "specs": ["Masonry"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/Masonry.git",
                 "hash": "02e53e5"
             },
-            "specs": ["Masonry"]
+            "specs": ["Masonry"],
+            "is_static": false
         }
     },
     "MessagingUIViews": {
-        "podbuilder_name": "MessagingUIViews",
-        "framework_path": "Rome/MessagingUIViews.framework",
+        "framework_path": "Frameworks/Rome/MessagingUIViews.framework",
         "restore_info": {
             "version": {
                 "tag": "13.14.6"
             },
-            "specs": ["MessagingUIViews/Core"]
+            "specs": ["MessagingUIViews/Core"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
             "version": {
                 "tag": "13.14.6"
             },
-            "specs": ["MessagingUIViews/Core"]
+            "specs": ["MessagingUIViews/Core"],
+            "is_static": false
         }
     },
     "Nimble": {
-        "podbuilder_name": "Nimble",
-        "framework_path": "Rome/Nimble.framework",
+        "framework_path": "Frameworks/Rome/Nimble.framework",
         "restore_info": {
             "version": {
                 "tag": "7.3.0"
             },
-            "specs": ["Nimble"]
+            "specs": ["Nimble"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
             "version": {
                 "tag": "7.3.0"
             },
-            "specs": ["Nimble"]
+            "specs": ["Nimble"],
+            "is_static": false
         }
     },
     "OptimizelySDKCore": {
-        "podbuilder_name": "OptimizelySDKCore",
-        "framework_path": "Rome/OptimizelySDKCore.framework",
+        "framework_path": "Frameworks/Rome/OptimizelySDKCore.framework",
         "restore_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKCore"]
+            "specs": ["OptimizelySDKCore"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKCore"]
+            "specs": ["OptimizelySDKCore"],
+            "is_static": false
         }
     },
     "OptimizelySDKDatafileManager": {
-        "podbuilder_name": "OptimizelySDKDatafileManager",
-        "framework_path": "Rome/OptimizelySDKDatafileManager.framework",
+        "framework_path": "Frameworks/Rome/OptimizelySDKDatafileManager.framework",
         "restore_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKDatafileManager"]
+            "specs": ["OptimizelySDKDatafileManager"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKDatafileManager"]
+            "specs": ["OptimizelySDKDatafileManager"],
+            "is_static": false
         }
     },
     "OptimizelySDKEventDispatcher": {
-        "podbuilder_name": "OptimizelySDKEventDispatcher",
-        "framework_path": "Rome/OptimizelySDKEventDispatcher.framework",
+        "framework_path": "Frameworks/Rome/OptimizelySDKEventDispatcher.framework",
         "restore_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKEventDispatcher"]
+            "specs": ["OptimizelySDKEventDispatcher"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKEventDispatcher"]
+            "specs": ["OptimizelySDKEventDispatcher"],
+            "is_static": false
         }
     },
     "OptimizelySDKShared": {
-        "podbuilder_name": "OptimizelySDKShared",
-        "framework_path": "Rome/OptimizelySDKShared.framework",
+        "framework_path": "Frameworks/Rome/OptimizelySDKShared.framework",
         "restore_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKShared"]
+            "specs": ["OptimizelySDKShared"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKShared"]
+            "specs": ["OptimizelySDKShared"],
+            "is_static": false
         }
     },
     "OptimizelySDKUserProfileService": {
-        "podbuilder_name": "OptimizelySDKUserProfileService",
-        "framework_path": "Rome/OptimizelySDKUserProfileService.framework",
+        "framework_path": "Frameworks/Rome/OptimizelySDKUserProfileService.framework",
         "restore_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKUserProfileService"]
+            "specs": ["OptimizelySDKUserProfileService"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKUserProfileService"]
+            "specs": ["OptimizelySDKUserProfileService"],
+            "is_static": false
         }
     },
     "OptimizelySDKiOS": {
-        "podbuilder_name": "OptimizelySDKiOS",
-        "framework_path": "Rome/OptimizelySDKiOS.framework",
+        "framework_path": "Frameworks/Rome/OptimizelySDKiOS.framework",
         "restore_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKiOS"]
+            "specs": ["OptimizelySDKiOS"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.5.1"
             },
-            "specs": ["OptimizelySDKiOS"]
+            "specs": ["OptimizelySDKiOS"],
+            "is_static": false
         }
     },
     "PrebidMobile": {
-        "podbuilder_name": "PrebidMobile",
-        "framework_path": "Rome/PrebidMobile.framework",
+        "framework_path": "Frameworks/Rome/PrebidMobile.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/prebid-mobile-ios.git",
                 "hash": "5a0c5da31b08cea8191cab528ff568ddf0302096"
             },
-            "specs": ["PrebidMobile"]
+            "specs": ["PrebidMobile"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/prebid-mobile-ios.git",
                 "hash": "5a0c5da31b08cea8191cab528ff568ddf0302096"
             },
-            "specs": ["PrebidMobile"]
+            "specs": ["PrebidMobile"],
+            "is_static": false
         }
     },
     "QBImagePickerController": {
-        "podbuilder_name": "QBImagePickerController",
-        "framework_path": "Rome/QBImagePickerController.framework",
+        "framework_path": "Frameworks/Rome/QBImagePickerController.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/QBImagePicker.git",
                 "hash": "9474d6e"
             },
-            "specs": ["QBImagePickerController"]
+            "specs": ["QBImagePickerController"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/QBImagePicker.git",
                 "hash": "9474d6e"
             },
-            "specs": ["QBImagePickerController"]
+            "specs": ["QBImagePickerController"],
+            "is_static": false
         }
     },
     "Quick": {
-        "podbuilder_name": "Quick",
-        "framework_path": "Rome/Quick.framework",
+        "framework_path": "Frameworks/Rome/Quick.framework",
         "restore_info": {
             "version": {
                 "tag": "1.2.0"
             },
-            "specs": ["Quick"]
+            "specs": ["Quick"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
             "version": {
                 "tag": "1.2.0"
             },
-            "specs": ["Quick"]
+            "specs": ["Quick"],
+            "is_static": false
+        }
+    },
+    "RXPromise": {
+        "framework_path": "Frameworks/Rome/RXPromise.framework",
+        "restore_info": {
+            "version": {
+                "tag": "0.13.1"
+            },
+            "specs": ["RXPromise"],
+            "is_static": false
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "0.13.1"
+            },
+            "specs": ["RXPromise"],
+            "is_static": false
         }
     },
     "SAMKeychain": {
-        "podbuilder_name": "SAMKeychain",
-        "framework_path": "Rome/SAMKeychain.framework",
+        "framework_path": "Frameworks/Rome/SAMKeychain.framework",
         "restore_info": {
             "version": {
                 "tag": "1.5.3"
             },
-            "specs": ["SAMKeychain"]
+            "specs": ["SAMKeychain"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "1.5.3"
             },
-            "specs": ["SAMKeychain"]
+            "specs": ["SAMKeychain"],
+            "is_static": false
         }
     },
     "SAMTextView": {
-        "podbuilder_name": "SAMTextView",
-        "framework_path": "Rome/SAMTextView.framework",
+        "framework_path": "Frameworks/Rome/SAMTextView.framework",
         "restore_info": {
             "version": {
                 "tag": "0.2.1"
             },
-            "specs": ["SAMTextView"]
+            "specs": ["SAMTextView"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "0.2.1"
             },
-            "specs": ["SAMTextView"]
+            "specs": ["SAMTextView"],
+            "is_static": false
+        }
+    },
+    "SDWebImage": {
+        "framework_path": "Frameworks/Rome/SDWebImage.framework",
+        "restore_info": {
+            "version": {
+                "tag": "4.4.5"
+            },
+            "specs": ["SDWebImage/Core", "SDWebImage/GIF"],
+            "is_static": false
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "4.4.5"
+            },
+            "specs": ["SDWebImage/Core", "SDWebImage/GIF"],
+            "is_static": false
         }
     },
     "SKPhotoBrowser": {
-        "podbuilder_name": "SKPhotoBrowser",
-        "framework_path": "Rome/SKPhotoBrowser.framework",
+        "framework_path": "Frameworks/Rome/SKPhotoBrowser.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/SKPhotoBrowser.git",
                 "hash": "bf1174e"
             },
-            "specs": ["SKPhotoBrowser"]
+            "specs": ["SKPhotoBrowser"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
@@ -546,135 +666,143 @@
                 "repo": "https://github.com/some_username/SKPhotoBrowser.git",
                 "hash": "bf1174e"
             },
-            "specs": ["SKPhotoBrowser"]
+            "specs": ["SKPhotoBrowser"],
+            "is_static": false
         }
     },
     "SVProgressHUD": {
-        "podbuilder_name": "SVProgressHUD",
-        "framework_path": "Rome/SVProgressHUD.framework",
+        "framework_path": "Frameworks/Rome/SVProgressHUD.framework",
         "restore_info": {
             "version": {
                 "tag": "2.2.5"
             },
-            "specs": ["SVProgressHUD"]
+            "specs": ["SVProgressHUD"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "tag": "2.2.5"
             },
-            "specs": ["SVProgressHUD"]
+            "specs": ["SVProgressHUD"],
+            "is_static": false
         }
     },
     "SVPullToRefresh": {
-        "podbuilder_name": "SVPullToRefresh",
-        "framework_path": "Rome/SVPullToRefresh.framework",
+        "framework_path": "Frameworks/Rome/SVPullToRefresh.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/SVPullToRefresh.git",
                 "hash": "d2294cc"
             },
-            "specs": ["SVPullToRefresh"]
+            "specs": ["SVPullToRefresh"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/SVPullToRefresh.git",
                 "hash": "d2294cc"
             },
-            "specs": ["SVPullToRefresh"]
+            "specs": ["SVPullToRefresh"],
+            "is_static": false
         }
     },
     "SwipeCellKit": {
-        "podbuilder_name": "SwipeCellKit",
-        "framework_path": "Rome/SwipeCellKit.framework",
+        "framework_path": "Frameworks/Rome/SwipeCellKit.framework",
         "restore_info": {
             "version": {
                 "tag": "2.5.0"
             },
-            "specs": ["SwipeCellKit"]
+            "specs": ["SwipeCellKit"],
+            "is_static": false,
+            "swift_version": "swiftlang-1000.11.42"
         },
         "prebuilt_info": {
             "swift_version": "swiftlang-1000.11.42",
             "version": {
                 "tag": "2.5.0"
             },
-            "specs": ["SwipeCellKit"]
+            "specs": ["SwipeCellKit"],
+            "is_static": false
         }
     },
     "TMReachability": {
-        "podbuilder_name": "TMReachability",
-        "framework_path": "Rome/TMReachability.framework",
+        "framework_path": "Frameworks/Rome/TMReachability.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/Reachability.git",
                 "hash": "e34782b"
             },
-            "specs": ["TMReachability"]
+            "specs": ["TMReachability"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/Reachability.git",
                 "hash": "e34782b"
             },
-            "specs": ["TMReachability"]
+            "specs": ["TMReachability"],
+            "is_static": false
         }
     },
     "TOCropViewController": {
-        "podbuilder_name": "TOCropViewController",
-        "framework_path": "Rome/TOCropViewController.framework",
+        "framework_path": "Frameworks/Rome/TOCropViewController.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/TOCropViewController.git",
                 "hash": "82f6696"
             },
-            "specs": ["TOCropViewController"]
+            "specs": ["TOCropViewController"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/TOCropViewController.git",
                 "hash": "82f6696"
             },
-            "specs": ["TOCropViewController"]
+            "specs": ["TOCropViewController"],
+            "is_static": false
         }
     },
     "TTTAttributedLabel": {
-        "podbuilder_name": "TTTAttributedLabel",
-        "framework_path": "Rome/TTTAttributedLabel.framework",
+        "framework_path": "Frameworks/Rome/TTTAttributedLabel.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/TTTAttributedLabel.git",
                 "hash": "2650bc9"
             },
-            "specs": ["TTTAttributedLabel"]
+            "specs": ["TTTAttributedLabel"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/TTTAttributedLabel.git",
                 "hash": "2650bc9"
             },
-            "specs": ["TTTAttributedLabel"]
+            "specs": ["TTTAttributedLabel"],
+            "is_static": false
         }
     },
     "UIWebView-Markdown": {
-        "podbuilder_name": "UIWebView-Markdown",
-        "framework_path": "Rome/UIWebView_Markdown.framework",
+        "framework_path": "Frameworks/Rome/UIWebView_Markdown.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/some_username/UIWebView-Markdown.git",
                 "tag": "1.0.3"
             },
-            "specs": ["UIWebView-Markdown"]
+            "specs": ["UIWebView-Markdown"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/some_username/UIWebView-Markdown.git",
                 "tag": "1.0.3"
             },
-            "specs": ["UIWebView-Markdown"]
+            "specs": ["UIWebView-Markdown"],
+            "is_static": false
         }
     },
     "XMPPFramework-Schibsted": {
-        "podbuilder_name": "XMPPFramework-Schibsted",
-        "framework_path": "Rome/XMPPFramework.framework",
+        "framework_path": "Frameworks/Rome/XMPPFramework.framework",
         "restore_info": {
             "version": {
                 "tag": "3.7.7"
@@ -686,7 +814,8 @@
                 "XMPPFramework-Schibsted/XEP-0138",
                 "XMPPFramework-Schibsted/XEP-0184",
                 "XMPPFramework-Schibsted/XEP-0199"
-            ]
+            ],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
@@ -699,12 +828,12 @@
                 "XMPPFramework-Schibsted/XEP-0138",
                 "XMPPFramework-Schibsted/XEP-0184",
                 "XMPPFramework-Schibsted/XEP-0199"
-            ]
+            ],
+            "is_static": false
         }
     },
     "libextobjc": {
-        "podbuilder_name": "libextobjc",
-        "framework_path": "Rome/libextobjc.framework",
+        "framework_path": "Frameworks/Rome/libextobjc.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/jspahrsummers/libextobjc.git",
@@ -713,7 +842,8 @@
             "specs": [
                 "libextobjc/EXTKeyPathCoding",
                 "libextobjc/RuntimeExtensions"
-            ]
+            ],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
@@ -723,25 +853,27 @@
             "specs": [
                 "libextobjc/EXTKeyPathCoding",
                 "libextobjc/RuntimeExtensions"
-            ]
+            ],
+            "is_static": false
         }
     },
     "sundown": {
-        "podbuilder_name": "sundown",
-        "framework_path": "Rome/sundown.framework",
+        "framework_path": "Frameworks/Rome/sundown.framework",
         "restore_info": {
             "version": {
                 "repo": "https://github.com/Daij-Djan/sundown.git",
                 "hash": "6bd8a7f50"
             },
-            "specs": ["sundown"]
+            "specs": ["sundown"],
+            "is_static": false
         },
         "prebuilt_info": {
             "version": {
                 "repo": "https://github.com/Daij-Djan/sundown.git",
                 "hash": "6bd8a7f50"
             },
-            "specs": ["sundown"]
+            "specs": ["sundown"],
+            "is_static": false
         }
     }
 }

--- a/PodBuilderInfo.json
+++ b/PodBuilderInfo.json
@@ -1,0 +1,747 @@
+{
+    "AFNetworking": {
+        "podbuilder_name": "AFNetworking",
+        "framework_path": "Rome/AFNetworking.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/AFNetworking.git",
+                "hash": "c683ebf"
+            },
+            "specs": [
+                "AFNetworking/NSURLSession",
+                "AFNetworking/Reachability",
+                "AFNetworking/Security",
+                "AFNetworking/Serialization",
+                "AFNetworking/UIKit"
+            ]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/AFNetworking.git",
+                "hash": "c683ebf"
+            },
+            "specs": [
+                "AFNetworking/UIKit",
+                "AFNetworking/NSURLSession",
+                "AFNetworking/Serialization",
+                "AFNetworking/Security",
+                "AFNetworking/Reachability"
+            ]
+        }
+    },
+    "AGWindowView": {
+        "podbuilder_name": "AGWindowView",
+        "framework_path": "Rome/AGWindowView.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/AGWindowView.git",
+                "hash": "cef7821"
+            },
+            "specs": ["AGWindowView"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/AGWindowView.git",
+                "hash": "cef7821"
+            },
+            "specs": ["AGWindowView"]
+        }
+    },
+    "ATInternet-Apple-SDK": {
+        "podbuilder_name": "ATInternet-Apple-SDK",
+        "framework_path": "Rome/Tracker.framework",
+        "restore_info": {
+            "version": {
+                "tag": "2.9.3"
+            },
+            "specs": ["ATInternet-Apple-SDK/Tracker"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "tag": "2.9.3"
+            },
+            "specs": ["ATInternet-Apple-SDK/Tracker"]
+        }
+    },
+    "BPForms": {
+        "podbuilder_name": "BPForms",
+        "framework_path": "Rome/BPForms.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/BPForms.git",
+                "hash": "17465e9"
+            },
+            "specs": ["BPForms/Core"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/BPForms.git",
+                "hash": "17465e9"
+            },
+            "specs": ["BPForms/Core"]
+        }
+    },
+    "BlocksKit": {
+        "podbuilder_name": "BlocksKit",
+        "framework_path": "Rome/BlocksKit.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/BlocksKit.git",
+                "hash": "1567645deb"
+            },
+            "specs": [
+                "BlocksKit",
+                "BlocksKit/All",
+                "BlocksKit/Core",
+                "BlocksKit/DynamicDelegate",
+                "BlocksKit/MessageUI",
+                "BlocksKit/QuickLook",
+                "BlocksKit/UIKit"
+            ]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/BlocksKit.git",
+                "hash": "1567645deb"
+            },
+            "specs": [
+                "BlocksKit",
+                "BlocksKit/All",
+                "BlocksKit/Core",
+                "BlocksKit/DynamicDelegate",
+                "BlocksKit/MessageUI",
+                "BlocksKit/QuickLook",
+                "BlocksKit/UIKit"
+            ]
+        }
+    },
+    "Bolts": {
+        "podbuilder_name": "Bolts",
+        "framework_path": "Rome/Bolts.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.9.0"
+            },
+            "specs": ["Bolts", "Bolts/AppLinks", "Bolts/Tasks"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.9.0"
+            },
+            "specs": ["Bolts", "Bolts/AppLinks", "Bolts/Tasks"]
+        }
+    },
+    "CocoaAsyncSocket": {
+        "podbuilder_name": "CocoaAsyncSocket",
+        "framework_path": "Rome/CocoaAsyncSocket.framework",
+        "restore_info": {
+            "version": {
+                "tag": "7.5.1"
+            },
+            "specs": ["CocoaAsyncSocket", "CocoaAsyncSocket/GCD"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "7.5.1"
+            },
+            "specs": ["CocoaAsyncSocket", "CocoaAsyncSocket/GCD"]
+        }
+    },
+    "DeepLinkParser": {
+        "podbuilder_name": "DeepLinkParser",
+        "framework_path": "Rome/DeepLinkParser.framework",
+        "restore_info": {
+            "version": {
+                "repo": "ssh://git@bitbucket.some_username.apa.net:7999/mob/deeplinkparser_swift.git",
+                "tag": "1.1.4"
+            },
+            "specs": ["DeepLinkParser"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "repo": "ssh://git@bitbucket.some_username.apa.net:7999/mob/deeplinkparser_swift.git",
+                "tag": "1.1.4"
+            },
+            "specs": ["DeepLinkParser"]
+        }
+    },
+    "FBSDKCoreKit": {
+        "podbuilder_name": "FBSDKCoreKit",
+        "framework_path": "Rome/FBSDKCoreKit.framework",
+        "restore_info": {
+            "version": {
+                "tag": "4.35.0"
+            },
+            "specs": ["FBSDKCoreKit"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "4.35.0"
+            },
+            "specs": ["FBSDKCoreKit"]
+        }
+    },
+    "FBSDKShareKit": {
+        "podbuilder_name": "FBSDKShareKit",
+        "framework_path": "Rome/FBSDKShareKit.framework",
+        "restore_info": {
+            "version": {
+                "tag": "4.35.0"
+            },
+            "specs": ["FBSDKShareKit"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "4.35.0"
+            },
+            "specs": ["FBSDKShareKit"]
+        }
+    },
+    "FLEX": {
+        "podbuilder_name": "FLEX",
+        "framework_path": "Rome/FLEX.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.1.1"
+            },
+            "specs": ["FLEX"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.1.1"
+            },
+            "specs": ["FLEX"]
+        }
+    },
+    "HighlanderFoundationKit": {
+        "podbuilder_name": "HighlanderFoundationKit",
+        "framework_path": "Rome/HighlanderFoundationKit.framework",
+        "restore_info": {
+            "version": {
+                "tag": "8.0.2"
+            },
+            "specs": ["HighlanderFoundationKit/Core"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "tag": "8.0.2"
+            },
+            "specs": ["HighlanderFoundationKit/Core"]
+        }
+    },
+    "KissXML": {
+        "podbuilder_name": "KissXML",
+        "framework_path": "Rome/KissXML.framework",
+        "restore_info": {
+            "version": {
+                "tag": "5.2.3"
+            },
+            "specs": ["KissXML"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "5.2.3"
+            },
+            "specs": ["KissXML"]
+        }
+    },
+    "Kiwi": {
+        "podbuilder_name": "Kiwi",
+        "framework_path": "Rome/Kiwi.framework",
+        "restore_info": {
+            "version": {
+                "tag": "3.0.0"
+            },
+            "specs": ["Kiwi"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "3.0.0"
+            },
+            "specs": ["Kiwi"]
+        }
+    },
+    "Knocker": {
+        "podbuilder_name": "Knocker",
+        "framework_path": "Rome/Knocker.framework",
+        "restore_info": {
+            "version": {
+                "tag": "5.2.0"
+            },
+            "specs": ["Knocker"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "tag": "5.2.0"
+            },
+            "specs": ["Knocker"]
+        }
+    },
+    "Mantle": {
+        "podbuilder_name": "Mantle",
+        "framework_path": "Rome/Mantle.framework",
+        "restore_info": {
+            "version": {
+                "tag": "2.1.0"
+            },
+            "specs": ["Mantle", "Mantle/extobjc"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "2.1.0"
+            },
+            "specs": ["Mantle", "Mantle/extobjc"]
+        }
+    },
+    "Masonry": {
+        "podbuilder_name": "Masonry",
+        "framework_path": "Rome/Masonry.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/Masonry.git",
+                "hash": "02e53e5"
+            },
+            "specs": ["Masonry"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/Masonry.git",
+                "hash": "02e53e5"
+            },
+            "specs": ["Masonry"]
+        }
+    },
+    "MessagingUIViews": {
+        "podbuilder_name": "MessagingUIViews",
+        "framework_path": "Rome/MessagingUIViews.framework",
+        "restore_info": {
+            "version": {
+                "tag": "13.14.6"
+            },
+            "specs": ["MessagingUIViews/Core"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "tag": "13.14.6"
+            },
+            "specs": ["MessagingUIViews/Core"]
+        }
+    },
+    "Nimble": {
+        "podbuilder_name": "Nimble",
+        "framework_path": "Rome/Nimble.framework",
+        "restore_info": {
+            "version": {
+                "tag": "7.3.0"
+            },
+            "specs": ["Nimble"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "tag": "7.3.0"
+            },
+            "specs": ["Nimble"]
+        }
+    },
+    "OptimizelySDKCore": {
+        "podbuilder_name": "OptimizelySDKCore",
+        "framework_path": "Rome/OptimizelySDKCore.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKCore"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKCore"]
+        }
+    },
+    "OptimizelySDKDatafileManager": {
+        "podbuilder_name": "OptimizelySDKDatafileManager",
+        "framework_path": "Rome/OptimizelySDKDatafileManager.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKDatafileManager"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKDatafileManager"]
+        }
+    },
+    "OptimizelySDKEventDispatcher": {
+        "podbuilder_name": "OptimizelySDKEventDispatcher",
+        "framework_path": "Rome/OptimizelySDKEventDispatcher.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKEventDispatcher"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKEventDispatcher"]
+        }
+    },
+    "OptimizelySDKShared": {
+        "podbuilder_name": "OptimizelySDKShared",
+        "framework_path": "Rome/OptimizelySDKShared.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKShared"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKShared"]
+        }
+    },
+    "OptimizelySDKUserProfileService": {
+        "podbuilder_name": "OptimizelySDKUserProfileService",
+        "framework_path": "Rome/OptimizelySDKUserProfileService.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKUserProfileService"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKUserProfileService"]
+        }
+    },
+    "OptimizelySDKiOS": {
+        "podbuilder_name": "OptimizelySDKiOS",
+        "framework_path": "Rome/OptimizelySDKiOS.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKiOS"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.5.1"
+            },
+            "specs": ["OptimizelySDKiOS"]
+        }
+    },
+    "PrebidMobile": {
+        "podbuilder_name": "PrebidMobile",
+        "framework_path": "Rome/PrebidMobile.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/prebid-mobile-ios.git",
+                "hash": "5a0c5da31b08cea8191cab528ff568ddf0302096"
+            },
+            "specs": ["PrebidMobile"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/prebid-mobile-ios.git",
+                "hash": "5a0c5da31b08cea8191cab528ff568ddf0302096"
+            },
+            "specs": ["PrebidMobile"]
+        }
+    },
+    "QBImagePickerController": {
+        "podbuilder_name": "QBImagePickerController",
+        "framework_path": "Rome/QBImagePickerController.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/QBImagePicker.git",
+                "hash": "9474d6e"
+            },
+            "specs": ["QBImagePickerController"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/QBImagePicker.git",
+                "hash": "9474d6e"
+            },
+            "specs": ["QBImagePickerController"]
+        }
+    },
+    "Quick": {
+        "podbuilder_name": "Quick",
+        "framework_path": "Rome/Quick.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.2.0"
+            },
+            "specs": ["Quick"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "tag": "1.2.0"
+            },
+            "specs": ["Quick"]
+        }
+    },
+    "SAMKeychain": {
+        "podbuilder_name": "SAMKeychain",
+        "framework_path": "Rome/SAMKeychain.framework",
+        "restore_info": {
+            "version": {
+                "tag": "1.5.3"
+            },
+            "specs": ["SAMKeychain"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "1.5.3"
+            },
+            "specs": ["SAMKeychain"]
+        }
+    },
+    "SAMTextView": {
+        "podbuilder_name": "SAMTextView",
+        "framework_path": "Rome/SAMTextView.framework",
+        "restore_info": {
+            "version": {
+                "tag": "0.2.1"
+            },
+            "specs": ["SAMTextView"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "0.2.1"
+            },
+            "specs": ["SAMTextView"]
+        }
+    },
+    "SKPhotoBrowser": {
+        "podbuilder_name": "SKPhotoBrowser",
+        "framework_path": "Rome/SKPhotoBrowser.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/SKPhotoBrowser.git",
+                "hash": "bf1174e"
+            },
+            "specs": ["SKPhotoBrowser"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "repo": "https://github.com/some_username/SKPhotoBrowser.git",
+                "hash": "bf1174e"
+            },
+            "specs": ["SKPhotoBrowser"]
+        }
+    },
+    "SVProgressHUD": {
+        "podbuilder_name": "SVProgressHUD",
+        "framework_path": "Rome/SVProgressHUD.framework",
+        "restore_info": {
+            "version": {
+                "tag": "2.2.5"
+            },
+            "specs": ["SVProgressHUD"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "2.2.5"
+            },
+            "specs": ["SVProgressHUD"]
+        }
+    },
+    "SVPullToRefresh": {
+        "podbuilder_name": "SVPullToRefresh",
+        "framework_path": "Rome/SVPullToRefresh.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/SVPullToRefresh.git",
+                "hash": "d2294cc"
+            },
+            "specs": ["SVPullToRefresh"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/SVPullToRefresh.git",
+                "hash": "d2294cc"
+            },
+            "specs": ["SVPullToRefresh"]
+        }
+    },
+    "SwipeCellKit": {
+        "podbuilder_name": "SwipeCellKit",
+        "framework_path": "Rome/SwipeCellKit.framework",
+        "restore_info": {
+            "version": {
+                "tag": "2.5.0"
+            },
+            "specs": ["SwipeCellKit"]
+        },
+        "prebuilt_info": {
+            "swift_version": "swiftlang-1000.11.42",
+            "version": {
+                "tag": "2.5.0"
+            },
+            "specs": ["SwipeCellKit"]
+        }
+    },
+    "TMReachability": {
+        "podbuilder_name": "TMReachability",
+        "framework_path": "Rome/TMReachability.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/Reachability.git",
+                "hash": "e34782b"
+            },
+            "specs": ["TMReachability"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/Reachability.git",
+                "hash": "e34782b"
+            },
+            "specs": ["TMReachability"]
+        }
+    },
+    "TOCropViewController": {
+        "podbuilder_name": "TOCropViewController",
+        "framework_path": "Rome/TOCropViewController.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/TOCropViewController.git",
+                "hash": "82f6696"
+            },
+            "specs": ["TOCropViewController"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/TOCropViewController.git",
+                "hash": "82f6696"
+            },
+            "specs": ["TOCropViewController"]
+        }
+    },
+    "TTTAttributedLabel": {
+        "podbuilder_name": "TTTAttributedLabel",
+        "framework_path": "Rome/TTTAttributedLabel.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/TTTAttributedLabel.git",
+                "hash": "2650bc9"
+            },
+            "specs": ["TTTAttributedLabel"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/TTTAttributedLabel.git",
+                "hash": "2650bc9"
+            },
+            "specs": ["TTTAttributedLabel"]
+        }
+    },
+    "UIWebView-Markdown": {
+        "podbuilder_name": "UIWebView-Markdown",
+        "framework_path": "Rome/UIWebView_Markdown.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/some_username/UIWebView-Markdown.git",
+                "tag": "1.0.3"
+            },
+            "specs": ["UIWebView-Markdown"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/some_username/UIWebView-Markdown.git",
+                "tag": "1.0.3"
+            },
+            "specs": ["UIWebView-Markdown"]
+        }
+    },
+    "XMPPFramework-Schibsted": {
+        "podbuilder_name": "XMPPFramework-Schibsted",
+        "framework_path": "Rome/XMPPFramework.framework",
+        "restore_info": {
+            "version": {
+                "tag": "3.7.7"
+            },
+            "specs": [
+                "XMPPFramework-Schibsted/Core",
+                "XMPPFramework-Schibsted/Reconnect",
+                "XMPPFramework-Schibsted/XEP-0085",
+                "XMPPFramework-Schibsted/XEP-0138",
+                "XMPPFramework-Schibsted/XEP-0184",
+                "XMPPFramework-Schibsted/XEP-0199"
+            ]
+        },
+        "prebuilt_info": {
+            "version": {
+                "tag": "3.7.7"
+            },
+            "specs": [
+                "XMPPFramework-Schibsted/Core",
+                "XMPPFramework-Schibsted/Reconnect",
+                "XMPPFramework-Schibsted/XEP-0085",
+                "XMPPFramework-Schibsted/XEP-0138",
+                "XMPPFramework-Schibsted/XEP-0184",
+                "XMPPFramework-Schibsted/XEP-0199"
+            ]
+        }
+    },
+    "libextobjc": {
+        "podbuilder_name": "libextobjc",
+        "framework_path": "Rome/libextobjc.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/jspahrsummers/libextobjc.git",
+                "hash": "a24a09d2df8dc5d533f5d9dfbef7cc78d3503a39"
+            },
+            "specs": [
+                "libextobjc/EXTKeyPathCoding",
+                "libextobjc/RuntimeExtensions"
+            ]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/jspahrsummers/libextobjc.git",
+                "hash": "a24a09d2df8dc5d533f5d9dfbef7cc78d3503a39"
+            },
+            "specs": [
+                "libextobjc/EXTKeyPathCoding",
+                "libextobjc/RuntimeExtensions"
+            ]
+        }
+    },
+    "sundown": {
+        "podbuilder_name": "sundown",
+        "framework_path": "Rome/sundown.framework",
+        "restore_info": {
+            "version": {
+                "repo": "https://github.com/Daij-Djan/sundown.git",
+                "hash": "6bd8a7f50"
+            },
+            "specs": ["sundown"]
+        },
+        "prebuilt_info": {
+            "version": {
+                "repo": "https://github.com/Daij-Djan/sundown.git",
+                "hash": "6bd8a7f50"
+            },
+            "specs": ["sundown"]
+        }
+    }
+}

--- a/Rome.cabal
+++ b/Rome.cabal
@@ -25,6 +25,7 @@ library
                        , Data.Carthage.TargetPlatform
                        , Data.Carthage.Common
                        , Data.Carthage.VersionFile
+                       , Data.PodBuilder.PodBuilderInfo
                        , Data.Romefile
                        , Data.S3Config
                        , Text.Parsec.Utils

--- a/src/Caches/Local/Downloading.hs
+++ b/src/Caches/Local/Downloading.hs
@@ -103,9 +103,9 @@ getBcsymbolmapFromLocalCache
   -> TargetPlatform -- ^ The `TargetPlatform` to limit the operation to
   -> DwarfUUID -- ^ The UUID of the bcsymbolmap
   -> ExceptT String m LBS.ByteString
-getBcsymbolmapFromLocalCache lCacheDir cachePrefix reverseRomeMap fVector platform dwarfUUID
+getBcsymbolmapFromLocalCache lCacheDir (CachePrefix prefix) reverseRomeMap fVector platform dwarfUUID
   = do
-    let finalBcsymbolmapLocalPath = bcsymbolmapLocalCachePath cachePrefix
+    let finalBcsymbolmapLocalPath = bcsymbolmapLocalCachePath prefix
     bcSymbolmapExistsInLocalCache <-
       liftIO . doesFileExist $ finalBcsymbolmapLocalPath
     if bcSymbolmapExistsInLocalCache
@@ -124,10 +124,9 @@ getBcsymbolmapFromLocalCache lCacheDir cachePrefix reverseRomeMap fVector platfo
  where
   bcsymbolmapLocalCachePath cPrefix =
     lCacheDir
-      </> temp_remoteBcSymbolmapPath platform
+      </> cPrefix </> temp_remoteBcSymbolmapPath platform
                                      reverseRomeMap
                                      fVector
-                                     cPrefix
                                      dwarfUUID
   --  TODO move to FrameworkVector?
   bcsymbolmapName =
@@ -146,7 +145,7 @@ getDSYMFromLocalCache
   -> FrameworkVector -- ^ The `FrameworkVector` identifying the dSYM
   -> TargetPlatform -- ^ The `TargetPlatform` to limit the operation to
   -> ExceptT String m LBS.ByteString
-getDSYMFromLocalCache lCacheDir cachePrefix reverseRomeMap fVector platform =
+getDSYMFromLocalCache lCacheDir (CachePrefix prefix) reverseRomeMap fVector platform =
   do
     let finalDSYMLocalPath = dSYMLocalCachePath
     dSYMExistsInLocalCache <- liftIO . doesFileExist $ finalDSYMLocalPath
@@ -167,7 +166,7 @@ getDSYMFromLocalCache lCacheDir cachePrefix reverseRomeMap fVector platform =
   -- TODO move to FrameworkVector?
   dSYMLocalCachePath =
     lCacheDir
-      </> temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix
+      </> prefix </> temp_remoteDsymPath platform reverseRomeMap fVector
   dSYMName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector) <> ".dSYM"
 

--- a/src/Caches/Local/Downloading.hs
+++ b/src/Caches/Local/Downloading.hs
@@ -57,6 +57,7 @@ getFrameworkFromLocalCache lCacheDir (CachePrefix prefix) reverseRomeMap (Framew
 
 
 -- | Retrieves a .version file from a local cache
+-- | Carthage only, not necessary for PodBuilder
 getVersionFileFromLocalCache
   :: MonadIO m
   => FilePath -- ^ The cache definition
@@ -366,6 +367,7 @@ getAndUnzipDSYMFromLocalCache lCacheDir reverseRomeMap fVersion@(FrameworkVersio
 
 
 -- | Gets a multiple .version file from a local cache and saves them to the appropriate location.
+-- | Carthage only, not necessary for PodBuilder
 getAndSaveVersionFilesFromLocalCache
   :: MonadIO m
   => FilePath -- ^ The cache definition.
@@ -377,6 +379,7 @@ getAndSaveVersionFilesFromLocalCache lCacheDir =
 
 
 -- | Gets a .version file from a local cache and copies it to the appropriate location.
+-- | Carthage only, not necessary for PodBuilder
 getAndSaveVersionFileFromLocalCache
   :: MonadIO m
   => FilePath -- ^ The cache definition.

--- a/src/Caches/Local/Downloading.hs
+++ b/src/Caches/Local/Downloading.hs
@@ -361,7 +361,6 @@ getAndUnzipDSYMFromLocalCache
 getAndUnzipDSYMFromLocalCache lCacheDir reverseRomeMap fVector platform
   = when (vectorSupportsPlatform fVector platform) $ do
     (cachePrefix@(CachePrefix prefix), verbose) <- ask
-    let finalDSYMLocalPath = dSYMLocalCachePath prefix
     let sayFunc            = if verbose then sayLnWithTime else sayLn
     binary <- getDSYMFromLocalCache lCacheDir
                                     cachePrefix
@@ -370,26 +369,25 @@ getAndUnzipDSYMFromLocalCache lCacheDir reverseRomeMap fVector platform
                                     platform
     sayFunc
       $  "Found "
-      <> dSYMName
+      <> verboseDSYMDebugName
       <> " in local cache at: "
-      <> finalDSYMLocalPath
+      <> verboseFinalDSYMLocalDebugPath prefix
     deleteDSYMDirectory fVector platform verbose
-    unzipBinary binary verboseFrameworkDebugName dSYMZipName verbose
+    unzipBinary binary verboseFrameworkDebugName verboseDSYMZipDebugName verbose
  where
   -- TODO move to FrameworkVector?
   dSYMLocalCachePath cPrefix = lCacheDir </> cPrefix </> remotedSYMUploadPath
-  remotedSYMUploadPath = remoteDsymPath
+  remotedSYMUploadPath = _remoteDsymPath (_vectorPaths fVector)
     platform
     reverseRomeMap
+  verboseDSYMZipDebugName = dSYMArchiveName
     (_framework $ _vectorFrameworkVersion fVector)
     (_frameworkVersion $ _vectorFrameworkVersion fVector)
-  dSYMZipName = dSYMArchiveName
-    (_framework $ _vectorFrameworkVersion fVector)
-    (_frameworkVersion $ _vectorFrameworkVersion fVector)
-  dSYMName =
+  verboseDSYMDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector) <> ".dSYM"
   verboseFrameworkDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
+  verboseFinalDSYMLocalDebugPath prefix = dSYMLocalCachePath prefix
 
 
 

--- a/src/Caches/Local/Downloading.hs
+++ b/src/Caches/Local/Downloading.hs
@@ -53,7 +53,7 @@ getFrameworkFromLocalCache lCacheDir (CachePrefix prefix) reverseRomeMap fVector
   frameworkLocalCachePath =
     lCacheDir
       </> prefix
-      </> _remoteFrameworkPath fVector platform reverseRomeMap
+      </> _remoteFrameworkPath (_vectorPaths fVector) platform reverseRomeMap
   --  TODO move to FrameworkVector?
   verboseFrameworkDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
@@ -207,7 +207,7 @@ getAndUnzipBcsymbolmapFromLocalCache buildTypeConfig lCacheDir reverseRomeMap fV
   frameworkLocalCachePath prefix =
     lCacheDir
       </> prefix
-      </> _remoteFrameworkPath fVector platform reverseRomeMap
+      </> _remoteFrameworkPath (_vectorPaths fVector) platform reverseRomeMap
   bcsymbolmapPath = temp_bcSymbolMapPath buildTypeConfig platform fVector
   -- TODO move to FrameworkVector?
   symbolmapName =
@@ -347,7 +347,7 @@ getAndUnzipFrameworkFromLocalCache buildTypeConfig lCacheDir reverseRomeMap fVec
   frameworkLocalCachePath prefix =
     lCacheDir
       </> prefix
-      </> _remoteFrameworkPath fVector platform reverseRomeMap
+      </> _remoteFrameworkPath (_vectorPaths fVector) platform reverseRomeMap
   -- TODO move to FrameworkVector?
   verboseFrameworkDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)

--- a/src/Caches/Local/Downloading.hs
+++ b/src/Caches/Local/Downloading.hs
@@ -53,7 +53,7 @@ getFrameworkFromLocalCache lCacheDir cachePrefix reverseRomeMap fVector platform
   --  TODO move to FrameworkVector?
   frameworkLocalCachePath cPrefix =
     lCacheDir
-      </> temp_remoteFrameworkUploadPath platform reverseRomeMap fVector cPrefix
+      </> temp_remoteFrameworkPath platform reverseRomeMap fVector cPrefix
   verboseFrameworkDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
 
@@ -123,11 +123,11 @@ getBcsymbolmapFromLocalCache lCacheDir cachePrefix reverseRomeMap fVector platfo
  where
   bcsymbolmapLocalCachePath cPrefix =
     lCacheDir
-      </> temp_remoteBcSymbolmapUploadPath platform
-                                           reverseRomeMap
-                                           fVector
-                                           cPrefix
-                                           dwarfUUID
+      </> temp_remoteBcSymbolmapPath platform
+                                     reverseRomeMap
+                                     fVector
+                                     cPrefix
+                                     dwarfUUID
   --  TODO move to FrameworkVector?
   bcsymbolmapName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
@@ -166,7 +166,7 @@ getDSYMFromLocalCache lCacheDir cachePrefix reverseRomeMap fVector platform =
   -- TODO move to FrameworkVector?
   dSYMLocalCachePath =
     lCacheDir
-      </> temp_remoteDsymUploadPath platform reverseRomeMap fVector cachePrefix
+      </> temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix
   dSYMName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector) <> ".dSYM"
 
@@ -207,7 +207,7 @@ getAndUnzipBcsymbolmapFromLocalCache buildTypeConfig lCacheDir reverseRomeMap fV
       <> bcsymbolmapNameFrom dwarfUUID
   frameworkLocalCachePath cPrefix =
     lCacheDir
-      </> temp_remoteFrameworkUploadPath platform reverseRomeMap fVector cPrefix
+      </> temp_remoteFrameworkPath platform reverseRomeMap fVector cPrefix
   bcsymbolmapZipName d = bcsymbolmapArchiveName
     d
     (_frameworkVersion $ _vectorFrameworkVersion fVector)
@@ -230,7 +230,7 @@ getAndUnzipBcsymbolmapsFromLocalCache buildTypeConfig lCacheDir reverseRomeMap f
     let sayFunc = if verbose then sayLnWithTime else sayLn
 
     dwarfUUIDs <- dwarfUUIDsFrom
-      $ temp_localFrameworkBinaryPath buildTypeConfig platform fVector
+      $ temp_frameworkBinaryPath buildTypeConfig platform fVector
     mapM_
       (\dwarfUUID ->
         getAndUnzipBcsymbolmapFromLocalCache buildTypeConfig
@@ -260,7 +260,7 @@ getAndUnzipBcsymbolmapsFromLocalCache'
 getAndUnzipBcsymbolmapsFromLocalCache' buildTypeConfig lCacheDir reverseRomeMap fVector platform
   = when (vectorSupportsPlatform fVector platform) $ do
     dwarfUUIDs <- withExceptT (const ErrorGettingDwarfUUIDs) $ dwarfUUIDsFrom
-      (temp_localFrameworkBinaryPath buildTypeConfig platform fVector)
+      (temp_frameworkBinaryPath buildTypeConfig platform fVector)
     eitherDwarfUUIDsOrSucces <- forM
       dwarfUUIDs
       (\dwarfUUID -> lift $ runExceptT
@@ -342,14 +342,14 @@ getAndUnzipFrameworkFromLocalCache buildTypeConfig lCacheDir reverseRomeMap fVec
   -- TODO move to FrameworkVector?
   frameworkLocalCachePath cPrefix =
     lCacheDir
-      </> temp_remoteFrameworkUploadPath platform reverseRomeMap fVector cPrefix
+      </> temp_remoteFrameworkPath platform reverseRomeMap fVector cPrefix
   verboseFrameworkDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
   frameworkZipName = frameworkArchiveName
     (_framework $ _vectorFrameworkVersion fVector)
     (_frameworkVersion $ _vectorFrameworkVersion fVector)
   frameworkExecutablePath =
-    temp_localFrameworkBinaryPath buildTypeConfig platform fVector
+    temp_frameworkBinaryPath buildTypeConfig platform fVector
 
 
 

--- a/src/Caches/Local/Probing.hs
+++ b/src/Caches/Local/Probing.hs
@@ -69,7 +69,7 @@ probeLocalCacheForFrameworkOnPlatform lCacheDir (CachePrefix prefix) reverseRome
  where
   frameworkLocalCachePath = lCacheDir </> prefix </> remoteFrameworkUploadPath
   remoteFrameworkUploadPath =
-    _remoteFrameworkPath frameworkVector platform reverseRomeMap
+    _remoteFrameworkPath (_vectorPaths frameworkVector) platform reverseRomeMap
 
 
 

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -43,6 +43,7 @@ saveFrameworkToLocalCache lCacheDir frameworkArchive reverseRomeMap fVector plat
       verboseDebugName
       verbose
  where
+  -- TODO move to FrameworkVector?
   verboseDebugName =
     appendFrameworkExtensionTo (_framework $ _vectorFrameworkVersion fVector)
 
@@ -66,6 +67,7 @@ saveDsymToLocalCache lCacheDir dSYMArchive reverseRomeMap fVector platform =
       verboseDebugName
       verbose
  where
+  -- TODO move to FrameworkVector?
   verboseDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector) <> ".dSYM"
 

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -115,6 +115,7 @@ saveBinaryToLocalCache cachePath binaryZip destinationPath objectName verbose =
 
 
 -- | Saves a list of .version files to a local cache
+-- | Carthage only, not necessary for PodBuilder
 saveVersionFilesToLocalCache
   :: FilePath -- ^ The cache definition.
   -> [ProjectNameAndVersion] -- ^ The information used to derive the name and path for the .version file.
@@ -125,6 +126,7 @@ saveVersionFilesToLocalCache lCacheDir =
 
 
 -- | Saves a .version file to a local Cache
+-- | Carthage only, not necessary for PodBuilder
 saveVersonFileToLocalCache
   :: FilePath -- ^ The cache definition.
   -> ProjectNameAndVersion -- ^ The information used to derive the name and path for the .version file.
@@ -147,6 +149,7 @@ saveVersonFileToLocalCache lCacheDir projectNameAndVersion = do
 
 
 -- | Saves a `LBS.ByteString` representing a .version file to a file.
+-- | Carthage only, not necessary for PodBuilder
 saveVersionFileBinaryToLocalCache
   :: MonadIO m
   => FilePath -- ^ The destinationf file.

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -31,15 +31,11 @@ saveFrameworkToLocalCache
   -> ReaderT (CachePrefix, SkipLocalCacheFlag, Bool) IO ()
 saveFrameworkToLocalCache lCacheDir frameworkArchive reverseRomeMap fVector platform
   = when (vectorSupportsPlatform fVector platform) $ do
-    (cachePrefix, SkipLocalCacheFlag skipLocalCache, verbose) <- ask
+    ((CachePrefix prefix), SkipLocalCacheFlag skipLocalCache, verbose) <- ask
     unless skipLocalCache $ saveBinaryToLocalCache
       lCacheDir
       (Zip.fromArchive frameworkArchive)
-      (temp_remoteFrameworkPath platform
-                                      reverseRomeMap
-                                      fVector
-                                      cachePrefix
-      )
+      (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
       verboseDebugName
       verbose
  where
@@ -88,10 +84,10 @@ saveBcsymbolmapToLocalCache lCacheDir dwarfUUID dwarfArchive reverseRomeMap fVec
       lCacheDir
       (Zip.fromArchive dwarfArchive)
       (temp_remoteBcSymbolmapPath platform
-                                        reverseRomeMap
-                                        fVector
-                                        cachePrefix
-                                        dwarfUUID
+                                  reverseRomeMap
+                                  fVector
+                                  cachePrefix
+                                  dwarfUUID
       )
       verboseDebugName
       verbose

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -37,7 +37,9 @@ saveFrameworkToLocalCache lCacheDir frameworkArchive reverseRomeMap fVector plat
     unless skipLocalCache $ saveBinaryToLocalCache
       lCacheDir
       (Zip.fromArchive frameworkArchive)
-      (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
+      (   prefix
+      </> _remoteFrameworkPath (_vectorPaths fVector) platform reverseRomeMap
+      )
       verboseDebugName
       verbose
  where

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -35,7 +35,7 @@ saveFrameworkToLocalCache lCacheDir frameworkArchive reverseRomeMap fVector plat
     unless skipLocalCache $ saveBinaryToLocalCache
       lCacheDir
       (Zip.fromArchive frameworkArchive)
-      (temp_remoteFrameworkUploadPath platform
+      (temp_remoteFrameworkPath platform
                                       reverseRomeMap
                                       fVector
                                       cachePrefix
@@ -63,7 +63,7 @@ saveDsymToLocalCache lCacheDir dSYMArchive reverseRomeMap fVector platform =
     unless skipLocalCache $ saveBinaryToLocalCache
       lCacheDir
       (Zip.fromArchive dSYMArchive)
-      (temp_remoteDsymUploadPath platform reverseRomeMap fVector cachePrefix)
+      (temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix)
       verboseDebugName
       verbose
  where
@@ -87,7 +87,7 @@ saveBcsymbolmapToLocalCache lCacheDir dwarfUUID dwarfArchive reverseRomeMap fVec
     unless skipLocalCache $ saveBinaryToLocalCache
       lCacheDir
       (Zip.fromArchive dwarfArchive)
-      (temp_remoteBcSymbolmapUploadPath platform
+      (temp_remoteBcSymbolmapPath platform
                                         reverseRomeMap
                                         fVector
                                         cachePrefix

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -55,11 +55,11 @@ saveDsymToLocalCache
   -> ReaderT (CachePrefix, SkipLocalCacheFlag, Bool) IO ()
 saveDsymToLocalCache lCacheDir dSYMArchive reverseRomeMap fVector platform =
   when (vectorSupportsPlatform fVector platform) $ do
-    (cachePrefix, SkipLocalCacheFlag skipLocalCache, verbose) <- ask
+    ((CachePrefix prefix), SkipLocalCacheFlag skipLocalCache, verbose) <- ask
     unless skipLocalCache $ saveBinaryToLocalCache
       lCacheDir
       (Zip.fromArchive dSYMArchive)
-      (temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix)
+      (prefix </> temp_remoteDsymPath platform reverseRomeMap fVector)
       verboseDebugName
       verbose
  where
@@ -79,15 +79,12 @@ saveBcsymbolmapToLocalCache
   -> ReaderT (CachePrefix, SkipLocalCacheFlag, Bool) IO ()
 saveBcsymbolmapToLocalCache lCacheDir dwarfUUID dwarfArchive reverseRomeMap fVector platform
   = when (vectorSupportsPlatform fVector platform) $ do
-    (cachePrefix, SkipLocalCacheFlag skipLocalCache, verbose) <- ask
+    ((CachePrefix prefix), SkipLocalCacheFlag skipLocalCache, verbose) <- ask
     unless skipLocalCache $ saveBinaryToLocalCache
       lCacheDir
       (Zip.fromArchive dwarfArchive)
-      (temp_remoteBcSymbolmapPath platform
-                                  reverseRomeMap
-                                  fVector
-                                  cachePrefix
-                                  dwarfUUID
+      (   prefix
+      </> temp_remoteBcSymbolmapPath platform reverseRomeMap fVector dwarfUUID
       )
       verboseDebugName
       verbose

--- a/src/Caches/Local/Uploading.hs
+++ b/src/Caches/Local/Uploading.hs
@@ -3,7 +3,6 @@ module Caches.Local.Uploading where
 
 
 import qualified Codec.Archive.Zip             as Zip
-import           Configuration
 import           Control.Monad                (unless, when)
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader         (ReaderT, ask)

--- a/src/Caches/S3/Downloading.hs
+++ b/src/Caches/S3/Downloading.hs
@@ -56,7 +56,9 @@ getFrameworkFromS3 s3BucketName reverseRomeMap fVector platform = do
     (withReaderT (const (env, verbose)))
     (getArtifactFromS3
       s3BucketName
-      (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
+      (   prefix
+      </> _remoteFrameworkPath (_vectorPaths fVector) platform reverseRomeMap
+      )
       verboseFrameworkDebugName
     )
  where

--- a/src/Caches/S3/Downloading.hs
+++ b/src/Caches/S3/Downloading.hs
@@ -49,12 +49,12 @@ getFrameworkFromS3
        (ReaderT (AWS.Env, CachePrefix, Bool) IO)
        LBS.ByteString
 getFrameworkFromS3 s3BucketName reverseRomeMap fVector platform = do
-  (env, cachePrefix, verbose) <- ask
+  (env, (CachePrefix prefix), verbose) <- ask
   mapExceptT
     (withReaderT (const (env, verbose)))
     (getArtifactFromS3
       s3BucketName
-      (temp_remoteFrameworkPath platform reverseRomeMap fVector cachePrefix)
+      (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
       verboseFrameworkDebugName
     )
  where

--- a/src/Caches/S3/Downloading.hs
+++ b/src/Caches/S3/Downloading.hs
@@ -75,9 +75,9 @@ getDSYMFromS3
        (ReaderT (AWS.Env, CachePrefix, Bool) IO)
        LBS.ByteString
 getDSYMFromS3 s3BucketName reverseRomeMap fVector platform = do
-  (env, cachePrefix, verbose) <- ask
+  (env, (CachePrefix prefix), verbose) <- ask
   let finalRemoteDSYMUploadPath =
-        temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix
+        prefix </> temp_remoteDsymPath platform reverseRomeMap fVector
   mapExceptT (withReaderT (const (env, verbose))) $ getArtifactFromS3
     s3BucketName
     finalRemoteDSYMUploadPath
@@ -124,13 +124,13 @@ getBcsymbolmapFromS3
        LBS.ByteString
 getBcsymbolmapFromS3 s3BucketName reverseRomeMap fVector platform dwarfUUID =
   do
-    (env, cachePrefix, verbose) <- ask
-    let finalRemoteBcsymbolmaploadPath = temp_remoteBcSymbolmapPath
-          platform
-          reverseRomeMap
-          fVector
-          cachePrefix
-          dwarfUUID
+    (env, (CachePrefix prefix), verbose) <- ask
+    let finalRemoteBcsymbolmaploadPath =
+          prefix
+            </> temp_remoteBcSymbolmapPath platform
+                                           reverseRomeMap
+                                           fVector
+                                           dwarfUUID
     mapExceptT (withReaderT (const (env, verbose))) $ getArtifactFromS3
       s3BucketName
       finalRemoteBcsymbolmaploadPath

--- a/src/Caches/S3/Downloading.hs
+++ b/src/Caches/S3/Downloading.hs
@@ -1,29 +1,38 @@
 module Caches.S3.Downloading where
 
 import           Caches.Common
-import           Configuration                (carthageArtifactsBuildDirectoryForPlatform)
-import           Control.Exception            (try)
-import           Control.Lens                 (view)
+import           Configuration                  ( carthageArtifactsBuildDirectoryForPlatform
+                                                )
+import           Control.Exception              ( try )
+import           Control.Lens                   ( view )
 import           Control.Monad
 import           Control.Monad.Except
-import           Control.Monad.Reader         (ReaderT, ask, runReaderT,
-                                               withReaderT)
-import qualified Data.ByteString              as BS
-import qualified Data.ByteString.Lazy         as LBS
+import           Control.Monad.Reader           ( ReaderT
+                                                , ask
+                                                , runReaderT
+                                                , withReaderT
+                                                )
+import qualified Data.ByteString               as BS
+import qualified Data.ByteString.Lazy          as LBS
 import           Data.Carthage.TargetPlatform
-import qualified Data.Conduit                 as C (ConduitT, await, yield,
-                                                    (.|))
-import qualified Data.Conduit.Binary          as C (sinkLbs)
-import           Data.Either                  (lefts)
-import           Data.Maybe                   (fromMaybe)
-import           Data.Monoid                  ((<>))
-import           Data.Romefile                (Framework (..))
-import qualified Data.Text                    as T
-import qualified Network.AWS                  as AWS
-import qualified Network.AWS.S3               as S3
-import           System.Directory             (doesFileExist)
-import           System.FilePath              ((</>))
-import           Types                        hiding (version)
+import qualified Data.Conduit                  as C
+                                                ( ConduitT
+                                                , await
+                                                , yield
+                                                , (.|)
+                                                )
+import qualified Data.Conduit.Binary           as C
+                                                ( sinkLbs )
+import           Data.Either                    ( lefts )
+import           Data.Maybe                     ( fromMaybe )
+import           Data.Monoid                    ( (<>) )
+import           Data.Romefile                  ( Framework(..) )
+import qualified Data.Text                     as T
+import qualified Network.AWS                   as AWS
+import qualified Network.AWS.S3                as S3
+import           System.Directory               (doesFileExist)
+import           System.FilePath                ( (</>) )
+import           Types                   hiding ( version )
 import           Utils
 import           Xcode.DWARF
 
@@ -75,6 +84,7 @@ getDSYMFromS3 s3BucketName reverseRomeMap (FrameworkVersion f@(Framework fwn fwt
 
 
 -- | Retrieves a .version file from S3
+-- | Carthage only, not necessary for PodBuilder
 getVersionFileFromS3
   :: S3.BucketName
   -> ProjectNameAndVersion

--- a/src/Caches/S3/Probing.hs
+++ b/src/Caches/S3/Probing.hs
@@ -67,7 +67,9 @@ probeS3ForFrameworkOnPlatform s3BucketName reverseRomeMap frameworkVector platfo
     S3.ObjectKey
       .   T.pack
       $   cPrefix
-      </> _remoteFrameworkPath frameworkVector platform reverseRomeMap
+      </> _remoteFrameworkPath (_vectorPaths frameworkVector)
+                               platform
+                               reverseRomeMap
 
 
 

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -1,17 +1,20 @@
 module Caches.S3.Uploading where
 
-import qualified Codec.Archive.Zip            as Zip
-import           Control.Monad                (when)
-import           Control.Monad.Reader         (ReaderT, ask, withReaderT)
-import qualified Data.ByteString.Lazy         as LBS
+import qualified Codec.Archive.Zip             as Zip
+import           Control.Monad                  ( when )
+import           Control.Monad.Reader           ( ReaderT
+                                                , ask
+                                                , withReaderT
+                                                )
+import qualified Data.ByteString.Lazy          as LBS
 import           Data.Carthage.TargetPlatform
-import           Data.Monoid                  ((<>))
-import           Data.Romefile                (Framework (..))
-import qualified Data.Text                    as T
-import qualified Network.AWS                  as AWS
-import qualified Network.AWS.S3               as S3
-import           System.FilePath              ((</>))
-import           Types                        hiding (version)
+import           Data.Monoid                    ( (<>) )
+import           Data.Romefile                  ( Framework(..) )
+import qualified Data.Text                     as T
+import qualified Network.AWS                   as AWS
+import qualified Network.AWS.S3                as S3
+import           System.FilePath                ( (</>) )
+import           Types                   hiding ( version )
 import           Utils
 import           Xcode.DWARF
 
@@ -83,6 +86,7 @@ uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap (Framew
 
 
 -- | Uploads a .version file to an S3 Bucket
+-- | Carthage only, not necessary for PodBuilder
 uploadVersionFileToS3
   :: S3.BucketName -- ^ The cache definition.
   -> LBS.ByteString -- ^ The contents of the .version file.

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -36,7 +36,9 @@ uploadFrameworkToS3 frameworkArchive s3BucketName reverseRomeMap fVector platfor
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive frameworkArchive)
-      (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
+      (   prefix
+      </> _remoteFrameworkPath (_vectorPaths fVector) platform reverseRomeMap
+      )
       verboseDebugName
  where
   -- TODO move to FrameworkVector?

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -30,15 +30,11 @@ uploadFrameworkToS3
   -> ReaderT UploadDownloadEnv IO ()
 uploadFrameworkToS3 frameworkArchive s3BucketName reverseRomeMap fVector platform
   = when (vectorSupportsPlatform fVector platform) $ do
-    (env, cachePrefix, verbose) <- ask
+    (env, (CachePrefix prefix), verbose) <- ask
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive frameworkArchive)
-      (temp_remoteFrameworkPath platform
-                                      reverseRomeMap
-                                      fVector
-                                      cachePrefix
-      )
+      (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
       verboseDebugName
  where
   -- TODO move to FrameworkVector?
@@ -87,10 +83,10 @@ uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap fVector
       s3BucketName
       (Zip.fromArchive dwarfArchive)
       (temp_remoteBcSymbolmapPath platform
-                                        reverseRomeMap
-                                        fVector
-                                        cachePrefix
-                                        dwarfUUID
+                                  reverseRomeMap
+                                  fVector
+                                  cachePrefix
+                                  dwarfUUID
       )
       verboseDebugName
  where

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -61,7 +61,8 @@ uploadDsymToS3 dSYMArchive s3BucketName reverseRomeMap fVector platform =
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive dSYMArchive)
-      (prefix </> temp_remoteDsymPath platform reverseRomeMap fVector)
+      (prefix </> _remoteDsymPath (_vectorPaths fVector) platform reverseRomeMap
+      )
       verboseDebugName
  where
   -- TODO move to FrameworkVector?
@@ -87,7 +88,10 @@ uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap fVector
       s3BucketName
       (Zip.fromArchive dwarfArchive)
       (   prefix
-      </> temp_remoteBcSymbolmapPath platform reverseRomeMap fVector dwarfUUID
+      </> _remoteBcSymbolmapPath (_vectorPaths fVector)
+                                 platform
+                                 reverseRomeMap
+                                 dwarfUUID
       )
       verboseDebugName
  where
@@ -110,8 +114,8 @@ uploadVersionFileToS3
 uploadVersionFileToS3 s3BucketName versionFileContent reverseRomeMap fVector =
   do
     case
-        ( temp_versionFileLocalPath reverseRomeMap fVector
-        , temp_versionFileRemotePath reverseRomeMap fVector
+        ( _versionFileLocalPath (_vectorPaths fVector) reverseRomeMap
+        , _versionFileRemotePath (_vectorPaths fVector) reverseRomeMap
         )
       of
         (Just versionFileLocalPath, Just versionFileRemotePath) -> do

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -41,6 +41,7 @@ uploadFrameworkToS3 frameworkArchive s3BucketName reverseRomeMap fVector platfor
       )
       verboseDebugName
  where
+  -- TODO move to FrameworkVector?
   verboseDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
 
@@ -63,6 +64,7 @@ uploadDsymToS3 dSYMArchive s3BucketName reverseRomeMap fVector platform =
       (temp_remoteDsymUploadPath platform reverseRomeMap fVector cachePrefix)
       verboseDebugName
  where
+  -- TODO move to FrameworkVector?
   verboseDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector) <> ".dSYM"
 
@@ -92,6 +94,7 @@ uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap fVector
       )
       verboseDebugName
  where
+  -- TODO move to FrameworkVector?
   verboseDebugName =
     (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
       <> "."

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -34,7 +34,7 @@ uploadFrameworkToS3 frameworkArchive s3BucketName reverseRomeMap fVector platfor
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive frameworkArchive)
-      (temp_remoteFrameworkUploadPath platform
+      (temp_remoteFrameworkPath platform
                                       reverseRomeMap
                                       fVector
                                       cachePrefix
@@ -61,7 +61,7 @@ uploadDsymToS3 dSYMArchive s3BucketName reverseRomeMap fVector platform =
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive dSYMArchive)
-      (temp_remoteDsymUploadPath platform reverseRomeMap fVector cachePrefix)
+      (temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix)
       verboseDebugName
  where
   -- TODO move to FrameworkVector?
@@ -86,7 +86,7 @@ uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap fVector
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive dwarfArchive)
-      (temp_remoteBcSymbolmapUploadPath platform
+      (temp_remoteBcSymbolmapPath platform
                                         reverseRomeMap
                                         fVector
                                         cachePrefix

--- a/src/Caches/S3/Uploading.hs
+++ b/src/Caches/S3/Uploading.hs
@@ -53,11 +53,11 @@ uploadDsymToS3
   -> ReaderT UploadDownloadEnv IO ()
 uploadDsymToS3 dSYMArchive s3BucketName reverseRomeMap fVector platform =
   when (vectorSupportsPlatform fVector platform) $ do
-    (env, cachePrefix, verbose) <- ask
+    (env, (CachePrefix prefix), verbose) <- ask
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive dSYMArchive)
-      (temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix)
+      (prefix </> temp_remoteDsymPath platform reverseRomeMap fVector)
       verboseDebugName
  where
   -- TODO move to FrameworkVector?
@@ -78,15 +78,12 @@ uploadBcsymbolmapToS3
   -> ReaderT UploadDownloadEnv IO ()
 uploadBcsymbolmapToS3 dwarfUUID dwarfArchive s3BucketName reverseRomeMap fVector platform
   = when (vectorSupportsPlatform fVector platform) $ do
-    (env, cachePrefix, verbose) <- ask
+    (env, (CachePrefix prefix), verbose) <- ask
     withReaderT (const (env, verbose)) $ uploadBinary
       s3BucketName
       (Zip.fromArchive dwarfArchive)
-      (temp_remoteBcSymbolmapPath platform
-                                  reverseRomeMap
-                                  fVector
-                                  cachePrefix
-                                  dwarfUUID
+      (   prefix
+      </> temp_remoteBcSymbolmapPath platform reverseRomeMap fVector dwarfUUID
       )
       verboseDebugName
  where

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -102,6 +102,15 @@ buildTypeParser = Opts.option
     )
     (readMaybe s)
 
+compilerVersionParser :: Opts.Parser String
+compilerVersionParser = Opts.strOption
+  (  Opts.value ""
+  <> Opts.metavar "VERSION"
+  <> Opts.long "compiler-version"
+  <> Opts.help
+       "Expected compiler version if relevant to the build output. Currently only used for Swift frameworks in PodBuilder projects, since Swift frameworks are not yet Module Stable and therefore can only be used in projects using the same compiler version. The compiler-version will be compared to the `swift_version` provided by `pod_builder info` and is used as part of the cache key. Provide it like this: `swift --version | head -1 | egrep -o 'swiftlang\\S+'`."
+  )
+
 udcPayloadParser :: Opts.Parser RomeUDCPayload
 udcPayloadParser =
   RomeUDCPayload
@@ -113,6 +122,7 @@ udcPayloadParser =
     <*> noSkipCurrentParser
     <*> concurrentlyParser
     <*> buildTypeParser
+    <*> compilerVersionParser
 
 uploadParser :: Opts.Parser RomeCommand
 uploadParser = pure Upload <*> udcPayloadParser
@@ -159,6 +169,7 @@ listPayloadParser =
     <*> noIgnoreParser
     <*> noSkipCurrentParser
     <*> buildTypeParser
+    <*> compilerVersionParser
 
 listParser :: Opts.Parser RomeCommand
 listParser = List <$> listPayloadParser

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -86,6 +86,22 @@ platformsParser
     filter (not . null) $ filter isLetter <$> wordsBy (not . isLetter) s
   platformListOrError s = mapM platformOrError $ splitPlatforms s
 
+buildTypeParser :: Opts.Parser BuildType
+buildTypeParser = Opts.option
+  (eitherReader buildTypeOrError)
+  (  Opts.value Carthage
+  <> Opts.metavar "TYPE"
+  <> Opts.long "build-type"
+  <> Opts.help "Build type of the project. One of Carthage or PodBuilder."
+  )
+ where
+  buildTypeOrError s = maybeToEither
+    (  "Unrecognized build-type '"
+    ++ s
+    ++ "', expected 'Carthage' or 'PodBuilder'"
+    )
+    (readMaybe s)
+
 udcPayloadParser :: Opts.Parser RomeUDCPayload
 udcPayloadParser =
   RomeUDCPayload
@@ -96,6 +112,7 @@ udcPayloadParser =
     <*> noIgnoreParser
     <*> noSkipCurrentParser
     <*> concurrentlyParser
+    <*> buildTypeParser
 
 uploadParser :: Opts.Parser RomeCommand
 uploadParser = pure Upload <*> udcPayloadParser
@@ -141,6 +158,7 @@ listPayloadParser =
     <*> printFormatParser
     <*> noIgnoreParser
     <*> noSkipCurrentParser
+    <*> buildTypeParser
 
 listParser :: Opts.Parser RomeCommand
 listParser = List <$> listPayloadParser

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -102,15 +102,6 @@ buildTypeParser = Opts.option
     )
     (readMaybe s)
 
-compilerVersionParser :: Opts.Parser String
-compilerVersionParser = Opts.strOption
-  (  Opts.value ""
-  <> Opts.metavar "VERSION"
-  <> Opts.long "compiler-version"
-  <> Opts.help
-       "Expected compiler version if relevant to the build output. Currently only used for Swift frameworks in PodBuilder projects, since Swift frameworks are not yet Module Stable and therefore can only be used in projects using the same compiler version. The compiler-version will be compared to the `swift_version` provided by `pod_builder info` and is used as part of the cache key. Provide it like this: `swift --version | head -1 | egrep -o 'swiftlang\\S+'`."
-  )
-
 udcPayloadParser :: Opts.Parser RomeUDCPayload
 udcPayloadParser =
   RomeUDCPayload
@@ -122,7 +113,6 @@ udcPayloadParser =
     <*> noSkipCurrentParser
     <*> concurrentlyParser
     <*> buildTypeParser
-    <*> compilerVersionParser
 
 uploadParser :: Opts.Parser RomeCommand
 uploadParser = pure Upload <*> udcPayloadParser
@@ -169,7 +159,6 @@ listPayloadParser =
     <*> noIgnoreParser
     <*> noSkipCurrentParser
     <*> buildTypeParser
-    <*> compilerVersionParser
 
 listParser :: Opts.Parser RomeCommand
 listParser = List <$> listPayloadParser

--- a/src/CommandParsers.hs
+++ b/src/CommandParsers.hs
@@ -189,17 +189,17 @@ parseRomeCommand =
     $  Opts.command
          "upload"
          (uploadParser
-         `withInfo` "Uploads frameworks and dSYMs contained in the local Carthage/Build/<platform> to S3, according to the local Cartfile.resolved"
+         `withInfo` "Uploads frameworks and dSYMs contained in the local Carthage/Build/<platform> (Carthage) or Frameworks/Rome (PodBuilder) to S3, according to the local Cartfile.resolved or `pod_builder info`"
          )
     <> Opts.command
          "download"
          (downloadParser
-         `withInfo` "Downloads and unpacks in Carthage/Build/<platform> frameworks and dSYMs found in S3, according to the local Cartfile.resolved"
+         `withInfo` "Downloads and unpacks in Carthage/Build/<platform> (Carthage) or Frameworks/Rome and Frameworks/dSYM (PodBuilder) frameworks and dSYMs found in S3, according to the local Cartfile.resolved or `pod_builder info`"
          )
     <> Opts.command
          "list"
          (listParser
-         `withInfo` "Lists frameworks in the cache and reports cache misses/hits, according to the local Cartfile.resolved. Ignores dSYMs."
+         `withInfo` "Lists frameworks in the cache and reports cache misses/hits, according to the local Cartfile.resolved  or `pod_builder info`. Ignores dSYMs."
          )
     <> Opts.command
          "utils"

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -1,11 +1,16 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+
 module Configuration where
 
 
 import           Control.Applicative             ((<|>))
 import           Control.Arrow                   (left)
+import           Control.Monad.Catch
 import           Control.Monad.Except
 import           Data.Carthage.Cartfile
 import           Data.Carthage.TargetPlatform
+import           Data.PodBuilder.PodBuilderInfo
 import           Data.Yaml                       (decodeFileEither, prettyPrintParseException)
 import           Data.Monoid                     ((<>))
 import           Data.Romefile
@@ -13,7 +18,41 @@ import qualified Data.Text.IO                    as T
 import           System.Directory
 import           System.FilePath
 import           Types
+import           Types.Commands                as Commands
 import           Debug.Trace
+
+
+buildTypeSpecificConfiguration
+  :: RomeCommand -> RomeMonad BuildTypeSpecificConfiguration
+buildTypeSpecificConfiguration command = do
+  case command of
+    -- TODO DRY
+    Upload (RomeUDCPayload { _buildType = Carthage }) -> do
+      cartfileEntries <- getCartfileEntries
+        `catch` \(e :: IOError) -> ExceptT . return $ Right []
+      return CarthageConfig {_cartfileEntries = cartfileEntries}
+    Download (RomeUDCPayload { _buildType = Carthage }) -> do
+      cartfileEntries <- getCartfileEntries
+        `catch` \(e :: IOError) -> ExceptT . return $ Right []
+      return CarthageConfig {_cartfileEntries = cartfileEntries}
+    List (RomeListPayload { _listBuildType = Carthage }) -> do
+      cartfileEntries <- getCartfileEntries
+        `catch` \(e :: IOError) -> ExceptT . return $ Right []
+      return CarthageConfig {_cartfileEntries = cartfileEntries}
+
+    Upload (RomeUDCPayload { _buildType = PodBuilder }) -> do
+      podBuilderInfo <- getPodBuilderInfo
+      return PodBuilderConfig {_podBuilderInfo = podBuilderInfo}
+    Download (RomeUDCPayload { _buildType = PodBuilder }) -> do
+      podBuilderInfo <- getPodBuilderInfo
+      return PodBuilderConfig {_podBuilderInfo = podBuilderInfo}
+    List (RomeListPayload { _listBuildType = PodBuilder }) -> do
+      podBuilderInfo <- getPodBuilderInfo
+      return PodBuilderConfig {_podBuilderInfo = podBuilderInfo}
+
+    _ ->
+      throwError
+        "Error: Programming Error. Only List, Download, Upload commands are supported."
 
 
 getCartfileEntries :: RomeMonad [CartfileEntry]
@@ -22,6 +61,13 @@ getCartfileEntries = do
   case eitherCartfileEntries of
     Left e -> throwError $ "Cartfile.resolved parse error: " ++ show e
     Right cartfileEntries -> return cartfileEntries
+
+getPodBuilderInfo :: RomeMonad PodBuilderInfo
+getPodBuilderInfo = do
+  eitherPodBuilderInfo <- parsePodBuilderInfo podBuilderInfoFileName
+  case eitherPodBuilderInfo of
+    Left e -> throwError $ "PodBuilderInfo.json parse error: " ++ show e
+    Right podBuilderInfo -> return podBuilderInfo
 
 getRomefileEntries :: FilePath -> RomeMonad Romefile
 getRomefileEntries absoluteRomefilePath =

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -86,6 +86,14 @@ getS3ConfigFile = (</> awsConfigFilePath) `liftM` liftIO getHomeDirectory
 carthageBuildDirectory :: FilePath
 carthageBuildDirectory = "Carthage" </> "Build"
 
+podBuilderBuildDirectory :: FilePath
+podBuilderBuildDirectory = "Frameworks" </> "Rome"
+
+artifactsBuildDirectoryForPlatform
+  :: BuildTypeSpecificConfiguration -> TargetPlatform -> Framework -> FilePath
+artifactsBuildDirectoryForPlatform buildTypeConfig = case buildTypeConfig of
+  CarthageConfig{}   -> carthageArtifactsBuildDirectoryForPlatform
+  PodBuilderConfig{} -> podBuilderArtifactsBuildDirectoryForPlatform
 
 -- | The Carthage build directory based on the `TargetPlatform` and the `FrameworkType`
 --   from `Framework`. Ignores the `TargetPlatform` list in `Framework`
@@ -95,3 +103,9 @@ carthageArtifactsBuildDirectoryForPlatform platform (Framework n Dynamic _) =
   carthageBuildDirectory </> show platform
 carthageArtifactsBuildDirectoryForPlatform platform (Framework n Static _) =
   carthageBuildDirectory </> show platform </> "Static"
+
+-- | The PodBuilder build directory
+podBuilderArtifactsBuildDirectoryForPlatform
+  :: TargetPlatform -> Framework -> FilePath
+podBuilderArtifactsBuildDirectoryForPlatform platform _ =
+  podBuilderBuildDirectory

--- a/src/Configuration.hs
+++ b/src/Configuration.hs
@@ -89,6 +89,9 @@ carthageBuildDirectory = "Carthage" </> "Build"
 podBuilderBuildDirectory :: FilePath
 podBuilderBuildDirectory = "Frameworks" </> "Rome"
 
+podBuilderDSYMDirectory :: FilePath
+podBuilderDSYMDirectory = "Frameworks" </> "dSYM"
+
 artifactsBuildDirectoryForPlatform
   :: BuildTypeSpecificConfiguration -> TargetPlatform -> Framework -> FilePath
 artifactsBuildDirectoryForPlatform buildTypeConfig = case buildTypeConfig of

--- a/src/Data/PodBuilder/PodBuilderInfo.hs
+++ b/src/Data/PodBuilder/PodBuilderInfo.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Data.PodBuilder.PodBuilderInfo
+  ( parsePodBuilderInfo
+  , podBuilderInfoFileName
+  , PodBuilderInfo
+  , PodInfo
+  )
+where
+
+import           GHC.Generics
+import           Data.Map
+import           Data.Aeson
+import qualified Data.ByteString.Lazy          as B
+
+type PodBuilderInfo = Map String PodInfo
+
+data PodInfo = PodInfo {
+  podbuilder_name :: String,
+  framework_path  :: String,
+  restore_info :: PodRestoreInfo,
+  prebuilt_info :: Maybe PodPrebuiltInfo }
+  deriving (Generic, Show)
+
+data PodRestoreInfo = PodRestoreInfo {
+  version :: PodVersion,
+  specs :: PodSpecs
+}
+  deriving (Generic, Show)
+
+data PodPrebuiltInfo = PodPrebuiltInfo {
+  swift_version :: Maybe String,
+  version :: PodVersion,
+  specs :: PodSpecs
+}
+  deriving (Generic, Show)
+
+data PodVersion = PodVersion {
+  repo :: Maybe String,
+  hash :: Maybe String,
+  tag :: Maybe String
+}
+  deriving (Generic, Show)
+
+type PodSpecs = [String]
+
+instance FromJSON PodInfo
+instance FromJSON PodRestoreInfo
+instance FromJSON PodPrebuiltInfo
+instance FromJSON PodVersion
+
+podBuilderInfoFileName :: String
+podBuilderInfoFileName = "PodBuilderInfo.json"
+
+-- `pod_builder info` output parsing
+
+parsePodBuilderInfoByteString :: B.ByteString -> Maybe PodBuilderInfo
+parsePodBuilderInfoByteString = decode
+
+parsePodBuilderInfo :: IO (Maybe PodBuilderInfo)
+parsePodBuilderInfo =
+  parsePodBuilderInfoByteString <$> B.readFile podBuilderInfoFileName
+

--- a/src/Data/PodBuilder/PodBuilderInfo.hs
+++ b/src/Data/PodBuilder/PodBuilderInfo.hs
@@ -10,14 +10,14 @@ module Data.PodBuilder.PodBuilderInfo
 where
 
 import           GHC.Generics
-import           Data.Map
+import qualified Data.Map.Strict               as Map
 import           Data.Aeson
 import qualified Data.ByteString.Lazy          as B
 import           Control.Monad.Trans            ( MonadIO
                                                 , liftIO
                                                 )
 
-type PodBuilderInfo = Map String PodInfo
+type PodBuilderInfo = Map.Map String PodInfo
 
 data PodInfo = PodInfo {
   podbuilder_name :: String,

--- a/src/Data/PodBuilder/PodBuilderInfo.hs
+++ b/src/Data/PodBuilder/PodBuilderInfo.hs
@@ -13,6 +13,9 @@ import           GHC.Generics
 import           Data.Map
 import           Data.Aeson
 import qualified Data.ByteString.Lazy          as B
+import           Control.Monad.Trans            ( MonadIO
+                                                , liftIO
+                                                )
 
 type PodBuilderInfo = Map String PodInfo
 
@@ -58,7 +61,7 @@ podBuilderInfoFileName = "PodBuilderInfo.json"
 parsePodBuilderInfoByteString :: B.ByteString -> Maybe PodBuilderInfo
 parsePodBuilderInfoByteString = decode
 
-parsePodBuilderInfo :: IO (Maybe PodBuilderInfo)
+parsePodBuilderInfo :: MonadIO m => m (Maybe PodBuilderInfo)
 parsePodBuilderInfo =
-  parsePodBuilderInfoByteString <$> B.readFile podBuilderInfoFileName
+  liftIO $ parsePodBuilderInfoByteString <$> B.readFile podBuilderInfoFileName
 

--- a/src/Data/PodBuilder/PodBuilderInfo.hs
+++ b/src/Data/PodBuilder/PodBuilderInfo.hs
@@ -7,8 +7,10 @@ module Data.PodBuilder.PodBuilderInfo
   , PodInfo
   , framework_path
   , restore_info
-  , restore_version
-  , restore_specs
+  , version
+  , specs
+  , is_static
+  , swift_version
   , repo
   , hash
   , tag
@@ -26,22 +28,16 @@ import           Control.Monad.Trans            ( MonadIO
 type PodBuilderInfo = Map.Map String PodInfo
 
 data PodInfo = PodInfo {
-  podbuilder_name :: String,
   framework_path  :: String,
-  restore_info :: PodRestoreInfo,
-  prebuilt_info :: Maybe PodPrebuiltInfo }
+  restore_info :: PodFrameworkInfo,
+  prebuilt_info :: Maybe PodFrameworkInfo }
   deriving (Generic, Show)
 
-data PodRestoreInfo = PodRestoreInfo {
-  restore_version :: PodVersion,
-  restore_specs :: PodSpecs
-}
-  deriving (Generic, Show)
-
-data PodPrebuiltInfo = PodPrebuiltInfo {
-  swift_version :: Maybe String,
-  prebuilt_version :: PodVersion,
-  prebuilt_specs :: PodSpecs
+data PodFrameworkInfo = PodFrameworkInfo {
+  version :: PodVersion,
+  specs :: PodSpecs,
+  is_static :: Bool,
+  swift_version :: Maybe String
 }
   deriving (Generic, Show)
 
@@ -55,21 +51,8 @@ data PodVersion = PodVersion {
 type PodSpecs = [String]
 
 instance FromJSON PodInfo
-instance FromJSON PodRestoreInfo where
-  parseJSON = genericParseJSON $ defaultOptions { fieldLabelModifier = podRestoreInfoPrefixing }
-instance FromJSON PodPrebuiltInfo where
-  parseJSON = genericParseJSON $ defaultOptions { fieldLabelModifier = podPrebuiltInfoPrefixing }
+instance FromJSON PodFrameworkInfo
 instance FromJSON PodVersion
-
-podRestoreInfoPrefixing :: String -> String
-podRestoreInfoPrefixing "restore_version" = "version"
-podRestoreInfoPrefixing "restore_specs"   = "specs"
-podRestoreInfoPrefixing a                 = a
-
-podPrebuiltInfoPrefixing :: String -> String
-podPrebuiltInfoPrefixing "prebuilt_version" = "version"
-podPrebuiltInfoPrefixing "prebuilt_specs"   = "specs"
-podPrebuiltInfoPrefixing a                  = a
 
 podBuilderInfoFileName :: String
 podBuilderInfoFileName = "PodBuilderInfo.json"

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -126,7 +126,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
 
   case command of
 
-    Upload (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg)
+    Upload (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg buildType)
       -> sayVersionWarning romeVersion verbose
         *> performWithDefaultFlow
              uploadArtifacts
@@ -144,7 +144,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
              mlCacheDir
              platforms
 
-    Download (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg)
+    Download (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg buildType)
       -> sayVersionWarning romeVersion verbose
         *> performWithDefaultFlow
              downloadArtifacts
@@ -162,7 +162,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
              mlCacheDir
              platforms
 
-    List (RomeListPayload listMode platforms cachePrefixString printFormat noIgnoreFlag noSkipCurrentFlag)
+    List (RomeListPayload listMode platforms cachePrefixString printFormat noIgnoreFlag noSkipCurrentFlag buildType)
       -> do
 
         currentVersion <- deriveCurrentVersion

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1007,7 +1007,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
                                                       platform
                 saveBinaryToLocalCache lCacheDir
                                        frameworkBinary
-                                       (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
+                                       (prefix </> _remoteFrameworkPath (_vectorPaths fVector) platform reverseRomeMap)
                                        verboseFrameworkDebugName
                                        verbose
                 deleteFrameworkDirectory buildTypeConfig fVector platform verbose

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -110,7 +110,28 @@ runUtilsCommand command absoluteRomefilePath verbose romeVersion =
 
 -- | Runs a command containing a `UDCPayload`   
 runUDCCommand :: RomeCommand -> FilePath -> Bool -> RomeVersion -> RomeMonad ()
-runUDCCommand command absoluteRomefilePath verbose romeVersion = do
+runUDCCommand command = do
+  case command of
+    Upload (RomeUDCPayload {_buildType=Carthage})
+      -> runUDCCommandCarthage command
+    Download (RomeUDCPayload {_buildType=Carthage})
+      -> runUDCCommandCarthage command
+    List (RomeListPayload {_listBuildType=Carthage})
+      -> runUDCCommandCarthage command
+
+    Upload (RomeUDCPayload {_buildType=PodBuilder})
+      -> runUDCCommandPodBuilder command
+    Download (RomeUDCPayload {_buildType=PodBuilder})
+      -> runUDCCommandPodBuilder command
+    List (RomeListPayload {_listBuildType=PodBuilder})
+      -> runUDCCommandPodBuilder command
+
+    _
+      -- default to carthage
+      -> runUDCCommandCarthage command
+
+runUDCCommandCarthage :: RomeCommand -> FilePath -> Bool -> RomeVersion -> RomeMonad ()
+runUDCCommandCarthage command absoluteRomefilePath verbose romeVersion = do
   cartfileEntries <- getCartfileEntries
     `catch` \(e :: IOError) -> ExceptT . return $ Right []
   romeFile <- getRomefileEntries absoluteRomefilePath
@@ -233,6 +254,18 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
       <> "You are currently on: "
       <> romeVersionToString vers
       <> noColorControlSequence
+
+runUDCCommandPodBuilder :: RomeCommand -> FilePath -> Bool -> RomeVersion -> RomeMonad ()
+runUDCCommandPodBuilder command absoluteRomefilePath verbose romeVersion = do
+  -- we don't need the repositoryMap, since PodBuilderInfo already contains that information
+  -- let repositoryMapEntries = _repositoryMapEntries romeFile
+  -- currentMap is not implemented for now
+  -- let currentMapEntries    = _currentMapEntries romeFile
+  -- TODO ignoreMap could be necessary in some corner cases
+  -- let ignoreMapEntries     = _ignoreMapEntries romeFile
+
+  throwError
+    "TODO implement"
 
 type FlowFunction  = Maybe S3.BucketName -- ^ Just an S3 Bucket name or Nothing
   -> Maybe FilePath -- ^ Just the path to the local cache or Nothing

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1049,7 +1049,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
                     saveBinaryToLocalCache
                       lCacheDir
                       symbolmapBinary
-                      (temp_remoteBcSymbolmapPath platform reverseRomeMap fVector cachePrefix dwarfUUID)
+                      (prefix </> temp_remoteBcSymbolmapPath platform reverseRomeMap fVector dwarfUUID)
                       verboseFrameworkDebugName
                       verbose
                     deleteFile (localBcsymbolmapPathFrom dwarfUUID) verbose
@@ -1083,7 +1083,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
                                             platform
                 saveBinaryToLocalCache lCacheDir
                                        dSYMBinary
-                                       (temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix)
+                                       (prefix </> temp_remoteDsymPath platform reverseRomeMap fVector)
                                        verboseDSYMDebugName
                                        verbose
                 deleteDSYMDirectory buildTypeConfig fVector platform  verbose

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -685,7 +685,7 @@ uploadFrameworkAndArtifactsToCaches buildTypeConfig s3BucketName mlCacheDir reve
     let uploadDownloadEnv = (env, cachePrefix, verbose)
 
     void . runExceptT $ do
-      frameworkArchive <- createZipArchive (temp_frameworkDirectory buildTypeConfig platform fVector) verbose
+      frameworkArchive <- createZipArchive (temp_frameworkPath buildTypeConfig platform fVector) verbose
       unless skipLocalCache
         $   maybe (return ()) liftIO
         $   runReaderT
@@ -707,7 +707,7 @@ uploadFrameworkAndArtifactsToCaches buildTypeConfig s3BucketName mlCacheDir reve
         uploadDownloadEnv
 
     void . runExceptT $ do
-      dSYMArchive <- createZipArchive (temp_dSYMdirectory buildTypeConfig platform fVector) verbose
+      dSYMArchive <- createZipArchive (temp_dSYMPath buildTypeConfig platform fVector) verbose
       unless skipLocalCache
         $   maybe (return ()) liftIO
         $   runReaderT
@@ -729,7 +729,7 @@ uploadFrameworkAndArtifactsToCaches buildTypeConfig s3BucketName mlCacheDir reve
         uploadDownloadEnv
 
     void . runExceptT $ do
-      dwarfUUIDs         <- dwarfUUIDsFrom $ temp_localFrameworkBinaryPath buildTypeConfig platform fVector
+      dwarfUUIDs         <- dwarfUUIDsFrom $ temp_frameworkBinaryPath buildTypeConfig platform fVector
       maybeUUIDsArchives <- liftIO $ forM dwarfUUIDs $ \dwarfUUID ->
         runMaybeT $ do
           dwarfArchive <- exceptToMaybeT
@@ -796,7 +796,7 @@ saveFrameworkAndArtifactsToLocalCache buildTypeConfig lCacheDir reverseRomeMap f
     let readerEnv = (cachePrefix, SkipLocalCacheFlag False, verbose)
 
     void . runExceptT $ do
-      frameworkArchive <- createZipArchive (temp_frameworkDirectory buildTypeConfig platform fVector) verbose
+      frameworkArchive <- createZipArchive (temp_frameworkPath buildTypeConfig platform fVector) verbose
       liftIO $ runReaderT
         (saveFrameworkToLocalCache lCacheDir
                                    frameworkArchive
@@ -807,7 +807,7 @@ saveFrameworkAndArtifactsToLocalCache buildTypeConfig lCacheDir reverseRomeMap f
         readerEnv
 
     void . runExceptT $ do
-      dSYMArchive <- createZipArchive (temp_dSYMdirectory buildTypeConfig platform fVector) verbose
+      dSYMArchive <- createZipArchive (temp_dSYMPath buildTypeConfig platform fVector) verbose
       liftIO $ runReaderT
         (saveDsymToLocalCache lCacheDir
                               dSYMArchive
@@ -818,7 +818,7 @@ saveFrameworkAndArtifactsToLocalCache buildTypeConfig lCacheDir reverseRomeMap f
         readerEnv
 
     void . runExceptT $ do
-      dwarfUUIDs         <- dwarfUUIDsFrom $ temp_localFrameworkBinaryPath buildTypeConfig platform fVector
+      dwarfUUIDs         <- dwarfUUIDsFrom $ temp_frameworkBinaryPath buildTypeConfig platform fVector
       maybeUUIDsArchives <- liftIO $ forM dwarfUUIDs $ \dwarfUUID ->
         runMaybeT $ do
           dwarfArchive <- exceptToMaybeT
@@ -1009,7 +1009,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
                                                       platform
                 saveBinaryToLocalCache lCacheDir
                                        frameworkBinary
-                                       (temp_remoteFrameworkUploadPath platform reverseRomeMap fVector cachePrefix)
+                                       (temp_remoteFrameworkPath platform reverseRomeMap fVector cachePrefix)
                                        verboseFrameworkDebugName
                                        verbose
                 deleteFrameworkDirectory buildTypeConfig fVector platform verbose
@@ -1049,7 +1049,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
                     saveBinaryToLocalCache
                       lCacheDir
                       symbolmapBinary
-                      (temp_remoteBcSymbolmapUploadPath platform reverseRomeMap fVector cachePrefix dwarfUUID)
+                      (temp_remoteBcSymbolmapPath platform reverseRomeMap fVector cachePrefix dwarfUUID)
                       verboseFrameworkDebugName
                       verbose
                     deleteFile (localBcsymbolmapPathFrom dwarfUUID) verbose
@@ -1083,7 +1083,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
                                             platform
                 saveBinaryToLocalCache lCacheDir
                                        dSYMBinary
-                                       (temp_remoteDsymUploadPath platform reverseRomeMap fVector cachePrefix)
+                                       (temp_remoteDsymPath platform reverseRomeMap fVector cachePrefix)
                                        verboseDSYMDebugName
                                        verbose
                 deleteDSYMDirectory buildTypeConfig fVector platform  verbose
@@ -1100,7 +1100,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
   verboseSymbolmapDebugName dwarfUUID = verboseFrameworkDebugName <> "." <> bcsymbolmapNameFrom dwarfUUID
   bcsymbolmapZipName d = bcsymbolmapArchiveName d (_frameworkVersion $ _vectorFrameworkVersion fVector)
   verboseSymbolmapZipDebugName dwarfUUID=bcsymbolmapZipName dwarfUUID
-  frameworkExecutablePath = temp_localFrameworkBinaryPath buildTypeConfig platform fVector
+  frameworkExecutablePath = temp_frameworkBinaryPath buildTypeConfig platform fVector
 
 
 downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName Nothing reverseRomeMap fVector platform

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -126,7 +126,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
 
   case command of
 
-    Upload (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg buildType)
+    Upload (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg buildType compilerVersion)
       -> sayVersionWarning romeVersion verbose
         *> performWithDefaultFlow
              uploadArtifacts
@@ -144,7 +144,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
              mlCacheDir
              platforms
 
-    Download (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg buildType)
+    Download (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg buildType compilerVersion)
       -> sayVersionWarning romeVersion verbose
         *> performWithDefaultFlow
              downloadArtifacts
@@ -162,7 +162,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
              mlCacheDir
              platforms
 
-    List (RomeListPayload listMode platforms cachePrefixString printFormat noIgnoreFlag noSkipCurrentFlag buildType)
+    List (RomeListPayload listMode platforms cachePrefixString printFormat noIgnoreFlag noSkipCurrentFlag buildType compilerVersion)
       -> do
 
         currentVersion <- deriveCurrentVersion

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -465,15 +465,13 @@ downloadArtifacts buildTypeConfig mS3BucketName mlCacheDir reverseRepositoryMap 
                                                         platforms
               )
               uploadDownloadEnv
-        let action2 = case buildTypeConfig of
-                        CarthageConfig{} -> runReaderT
-                                (downloadVersionFilesFromCaches s3BucketName
-                                                                lCacheDir
-                                                                reverseRepositoryMap
-                                                                frameworkVectors
-                                )
-                                uploadDownloadEnv
-                        PodBuilderConfig{} -> mempty -- PodBuilder does not have .version files, rather PodBuilder.plist files that are part of the .framework
+        let action2 = runReaderT
+              (downloadVersionFilesFromCaches s3BucketName
+                                              lCacheDir
+                                              reverseRepositoryMap
+                                              frameworkVectors
+              )
+              uploadDownloadEnv
         if performConcurrently
           then liftIO $ concurrently_ action1 action2
           else liftIO $ action1 >> action2
@@ -546,15 +544,13 @@ uploadArtifacts buildTypeConfig mS3BucketName mlCacheDir reverseRepositoryMap fr
                                                     platforms
               )
               uploadDownloadEnv
-        let action2 = case buildTypeConfig of
-                        CarthageConfig{} -> runReaderT
-                                (uploadVersionFilesToCaches s3BucketName
-                                                            lCacheDir
-                                                            reverseRepositoryMap
-                                                            frameworkVectors
-                                )
-                                uploadDownloadEnv
-                        PodBuilderConfig{} -> mempty -- PodBuilder does not have .version files, rather PodBuilder.plist files that are part of the .framework
+        let action2 = runReaderT
+              (uploadVersionFilesToCaches s3BucketName
+                                          lCacheDir
+                                          reverseRepositoryMap
+                                          frameworkVectors
+              )
+              uploadDownloadEnv
         if performConcurrently
           then liftIO $ concurrently_ action1 action2
           else liftIO $ action1 >> action2

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -970,7 +970,7 @@ downloadFrameworkAndArtifactsFromCaches
   -> ReaderT UploadDownloadCmdEnv IO ()
 downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCacheDir) reverseRomeMap fVector platform
   = do
-    (env, cachePrefix, SkipLocalCacheFlag skipLocalCache, _, verbose) <-
+    (env, cachePrefix@(CachePrefix prefix), SkipLocalCacheFlag skipLocalCache, _, verbose) <-
       ask
 
     let remoteReaderEnv = (env, cachePrefix, verbose)
@@ -1009,7 +1009,7 @@ downloadFrameworkAndArtifactsFromCaches buildTypeConfig s3BucketName (Just lCach
                                                       platform
                 saveBinaryToLocalCache lCacheDir
                                        frameworkBinary
-                                       (temp_remoteFrameworkPath platform reverseRomeMap fVector cachePrefix)
+                                       (prefix </> _remoteFrameworkPath fVector platform reverseRomeMap)
                                        verboseFrameworkDebugName
                                        verbose
                 deleteFrameworkDirectory buildTypeConfig fVector platform verbose

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -126,7 +126,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
 
   case command of
 
-    Upload (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg _ compilerVersion)
+    Upload (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg _)
       -> sayVersionWarning romeVersion verbose
         *> performWithDefaultFlow
              uploadArtifacts
@@ -144,7 +144,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
              mlCacheDir
              platforms
 
-    Download (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg _ compilerVersion)
+    Download (RomeUDCPayload gitRepoNames platforms cachePrefixString skipLocalCache noIgnoreFlag noSkipCurrentFlag concurrentlyFalg _)
       -> sayVersionWarning romeVersion verbose
         *> performWithDefaultFlow
              downloadArtifacts
@@ -162,7 +162,7 @@ runUDCCommand command absoluteRomefilePath verbose romeVersion = do
              mlCacheDir
              platforms
 
-    List (RomeListPayload listMode platforms cachePrefixString printFormat noIgnoreFlag noSkipCurrentFlag _ compilerVersion)
+    List (RomeListPayload listMode platforms cachePrefixString printFormat noIgnoreFlag noSkipCurrentFlag _)
       -> do
 
         currentVersion <- deriveCurrentVersion

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -35,11 +35,14 @@ newtype CachePrefix = CachePrefix { _unCachePrefix :: String }
 
 -- | Represents a framework with a mapping to local and remote paths
 data FrameworkVector = FrameworkVector { _vectorFrameworkVersion :: FrameworkVersion
-                                         , _remoteFrameworkPath :: TargetPlatform -> InvertedRepositoryMap -> String
+                                         , _vectorPaths :: FrameworkVectorPaths
                                        }
 
 instance Show FrameworkVector where
     show (FrameworkVector fv _) = "FrameworkVector " <> show fv
+
+data FrameworkVectorPaths = FrameworkVectorPaths { _remoteFrameworkPath :: TargetPlatform -> InvertedRepositoryMap -> FilePath
+                                                 }
 
 -- | Represents the name of a framework together with its version
 data FrameworkVersion = FrameworkVersion { _framework        :: Framework

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -34,8 +34,12 @@ newtype CachePrefix = CachePrefix { _unCachePrefix :: String }
                                   deriving (Show, Eq)
 
 -- | Represents a framework with a mapping to local and remote paths
-data FrameworkVector = FrameworkVector { _vectorFrameworkVersion :: FrameworkVersion }
-                                       deriving (Show, Eq)
+data FrameworkVector = FrameworkVector { _vectorFrameworkVersion :: FrameworkVersion
+                                         , _remoteFrameworkPath :: TargetPlatform -> InvertedRepositoryMap -> String
+                                       }
+
+instance Show FrameworkVector where
+    show (FrameworkVector fv _) = "FrameworkVector " <> show fv
 
 -- | Represents the name of a framework together with its version
 data FrameworkVersion = FrameworkVersion { _framework        :: Framework

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -3,8 +3,11 @@ module Types where
 
 import           Control.Monad.Except         (ExceptT)
 import           Data.Aeson
-import           Data.Carthage.Cartfile       (Version)
+import           Data.Carthage.Cartfile         ( Version
+                                                , CartfileEntry
+                                                )
 import           Data.Carthage.TargetPlatform
+import           Data.PodBuilder.PodBuilderInfo ( PodBuilderInfo )
 import qualified Data.Map.Strict              as M
 import           Data.Romefile                (Framework, ProjectName)
 import           GHC.Generics
@@ -69,3 +72,6 @@ instance ToJSON RepoJSON where
 newtype ReposJSON = ReposJSON [RepoJSON] deriving (Show, Eq, Generic)
 
 instance ToJSON ReposJSON where
+
+data BuildTypeSpecificConfiguration = CarthageConfig { _cartfileEntries :: [CartfileEntry] }
+                                    | PodBuilderConfig { _podBuilderInfo :: PodBuilderInfo }

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,18 +1,19 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Types where
 
-import           Control.Monad.Except         (ExceptT)
+import           Control.Monad.Except           ( ExceptT )
 import           Data.Aeson
 import           Data.Carthage.Cartfile         ( Version
                                                 , CartfileEntry
                                                 )
 import           Data.Carthage.TargetPlatform
 import           Data.PodBuilder.PodBuilderInfo ( PodBuilderInfo )
-import qualified Data.Map.Strict              as M
+import qualified Data.Map.Strict               as M
 import           Data.Romefile                (Framework, ProjectName)
 import           GHC.Generics
 import qualified Network.AWS.Env              as AWS (Env)
 import           Types.Commands
+import           Xcode.DWARF                    ( DwarfUUID )
 
 
 
@@ -41,7 +42,15 @@ data FrameworkVector = FrameworkVector { _vectorFrameworkVersion :: FrameworkVer
 instance Show FrameworkVector where
     show (FrameworkVector fv _) = "FrameworkVector " <> show fv
 
-data FrameworkVectorPaths = FrameworkVectorPaths { _remoteFrameworkPath :: TargetPlatform -> InvertedRepositoryMap -> FilePath
+data FrameworkVectorPaths = FrameworkVectorPaths { _frameworkPath :: TargetPlatform -> FilePath
+                                                 , _frameworkBinaryPath :: TargetPlatform -> FilePath
+                                                 , _dSYMPath :: TargetPlatform -> FilePath
+                                                 , _bcSymbolMapPath :: TargetPlatform -> DwarfUUID -> FilePath
+                                                 , _versionFileLocalPath :: InvertedRepositoryMap -> Maybe FilePath
+                                                 , _remoteFrameworkPath :: TargetPlatform -> InvertedRepositoryMap -> FilePath
+                                                 , _remoteDsymPath :: TargetPlatform -> InvertedRepositoryMap -> FilePath
+                                                 , _remoteBcSymbolmapPath :: TargetPlatform -> InvertedRepositoryMap -> DwarfUUID -> FilePath
+                                                 , _versionFileRemotePath :: InvertedRepositoryMap -> Maybe FilePath
                                                  }
 
 -- | Represents the name of a framework together with its version

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -33,6 +33,10 @@ type ProjectNameAndVersion = (ProjectName, Version)
 newtype CachePrefix = CachePrefix { _unCachePrefix :: String }
                                   deriving (Show, Eq)
 
+-- | Represents a framework with a mapping to local and remote paths
+data FrameworkVector = FrameworkVector { _vectorFrameworkVersion :: FrameworkVersion }
+                                       deriving (Show, Eq)
+
 -- | Represents the name of a framework together with its version
 data FrameworkVersion = FrameworkVersion { _framework        :: Framework
                                          , _frameworkVersion :: Version

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -2,6 +2,9 @@ module Types.Commands where
 
 import           Data.Romefile
 import           Data.Carthage.TargetPlatform
+import           Text.Read
+import qualified Text.Read.Lex                 as L
+import           Data.Char                      ( toLower )
 
 data RomeCommand = Upload RomeUDCPayload
                   | Download RomeUDCPayload
@@ -19,6 +22,7 @@ data RomeUDCPayload = RomeUDCPayload { _payload            :: [ProjectName]
                                      , _noIgnoreFlag       :: NoIgnoreFlag
                                      , _noSkipCurrentFlag  :: NoSkipCurrentFlag
                                      , _concurrentlyFlag   :: ConcurrentlyFlag
+                                     , _buildType          :: BuildType
                                      }
                                      deriving (Show, Eq)
 
@@ -43,12 +47,25 @@ newtype NoSkipCurrentFlag = NoSkipCurrentFlag { _noSkipCurrent :: Bool }
 newtype ConcurrentlyFlag = ConcurrentlyFlag { _concurrently :: Bool }
                                               deriving (Show, Eq)
 
+data BuildType = Carthage
+               | PodBuilder
+               deriving (Show, Eq)
+
+instance Read BuildType where
+  readPrec = parens $ do
+    L.Ident s <- lexP
+    case map toLower s of
+        "carthage"   -> return Carthage
+        "podbuilder" -> return PodBuilder
+        a            -> error $ "Unrecognized BuildType '" ++ a ++ "'"
+
 data RomeListPayload = RomeListPayload { _listMode              :: ListMode
                                        , _listPlatforms         :: [TargetPlatform]
                                        , _listCachePrefix       :: String
                                        , _listFormat            :: PrintFormat
                                        , _listNoIgnoreFlag      :: NoIgnoreFlag
                                        , _listNoSkipCurrentFlag :: NoSkipCurrentFlag
+                                       , _listBuildType         :: BuildType
                                        }
                                        deriving (Show, Eq)
 

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -23,6 +23,7 @@ data RomeUDCPayload = RomeUDCPayload { _payload            :: [ProjectName]
                                      , _noSkipCurrentFlag  :: NoSkipCurrentFlag
                                      , _concurrentlyFlag   :: ConcurrentlyFlag
                                      , _buildType          :: BuildType
+                                     , _compilerVersion    :: String
                                      }
                                      deriving (Show, Eq)
 
@@ -66,6 +67,7 @@ data RomeListPayload = RomeListPayload { _listMode              :: ListMode
                                        , _listNoIgnoreFlag      :: NoIgnoreFlag
                                        , _listNoSkipCurrentFlag :: NoSkipCurrentFlag
                                        , _listBuildType         :: BuildType
+                                       , _listCompilerVersion   :: String
                                        }
                                        deriving (Show, Eq)
 

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -57,7 +57,7 @@ instance Read BuildType where
     case map toLower s of
         "carthage"   -> return Carthage
         "podbuilder" -> return PodBuilder
-        a            -> error $ "Unrecognized BuildType '" ++ a ++ "'"
+        _ -> pfail
 
 data RomeListPayload = RomeListPayload { _listMode              :: ListMode
                                        , _listPlatforms         :: [TargetPlatform]

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -23,7 +23,6 @@ data RomeUDCPayload = RomeUDCPayload { _payload            :: [ProjectName]
                                      , _noSkipCurrentFlag  :: NoSkipCurrentFlag
                                      , _concurrentlyFlag   :: ConcurrentlyFlag
                                      , _buildType          :: BuildType
-                                     , _compilerVersion    :: String
                                      }
                                      deriving (Show, Eq)
 
@@ -67,7 +66,6 @@ data RomeListPayload = RomeListPayload { _listMode              :: ListMode
                                        , _listNoIgnoreFlag      :: NoIgnoreFlag
                                        , _listNoSkipCurrentFlag :: NoSkipCurrentFlag
                                        , _listBuildType         :: BuildType
-                                       , _listCompilerVersion   :: String
                                        }
                                        deriving (Show, Eq)
 

--- a/src/Types/Commands.hs
+++ b/src/Types/Commands.hs
@@ -54,11 +54,11 @@ data BuildType = Carthage
 
 instance Read BuildType where
   readPrec = parens $ do
-    L.Ident s <- lexP
-    case map toLower s of
-        "carthage"   -> return Carthage
-        "podbuilder" -> return PodBuilder
-        _ -> pfail
+        L.Ident s <- lexP
+        case map toLower s of
+            "carthage"   -> return Carthage
+            "podbuilder" -> return PodBuilder
+            _ -> pfail
 
 data RomeListPayload = RomeListPayload { _listMode              :: ListMode
                                        , _listPlatforms         :: [TargetPlatform]

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -481,9 +481,11 @@ deriveFrameworkNamesAndVersionPodBuilder romeMap =
       (\(k, v) -> FrameworkVersion
         { _framework        = Framework
           { _frameworkName      = fromMaybe (framework_path v)
-            . stripPrefix "Rome/"
+            . stripPrefix "Frameworks/Rome/"
             $ framework_path v
-          , _frameworkType      = Dynamic
+          , _frameworkType      = case PB.is_static (PB.restore_info v) of
+            True  -> Static
+            False -> Dynamic
           , _frameworkPlatforms = [IOS]
           }
         , _frameworkVersion = Version
@@ -494,8 +496,6 @@ deriveFrameworkNamesAndVersionPodBuilder romeMap =
       )
     . M.toList
   -- TODO also consider swift_version
-  -- TODO the path starts with `Rome/`, but probably should start with `Frameworks/Rome/`, need to talk to PodBuilder dev
-  -- TODO dynamic/static
   -- TODO generic target platform
   -- TODO restore_specs
 

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -8,6 +8,7 @@ module Utils where
 import qualified Codec.Archive.Zip             as Zip
 import           Configuration                  ( artifactsBuildDirectoryForPlatform
                                                 , carthageBuildDirectory
+                                                , podBuilderDSYMDirectory
                                                 )
 import           Control.Applicative            ( (<|>) )
 import           Control.Arrow                  ( left )
@@ -497,8 +498,9 @@ createFrameworkVectorForFrameworkVersion buildTypeConfig frameworkVersion =
                                      platformBuildPath p
                                        </> (frameworkNameWithFrameworkExtension <> ".dSYM")
                                    PodBuilderConfig _ ->
-                                     -- TODO correct path
-                                     platformBuildPath p
+                                     podBuilderDSYMDirectory
+                                      -- TODO PodBuilder builds separate dSYMs for iphonesimulator and iphoneos, but currently Rome can only cache one of the two
+                                       </> "iphonesimulator"
                                        </> (frameworkNameWithFrameworkExtension <> ".dSYM")
                                  )
       , _bcSymbolMapPath       = (\p d -> case buildTypeConfig of

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -334,30 +334,30 @@ filterRomeFileEntriesByPlatforms lhs rhs =
 
 
 
--- | Builds a string representing the remote path to a framework zip archive.
-remoteFrameworkPath
+-- | Builds a string representing the remote path to a framework zip archive for Carthage.
+remoteFrameworkPathCarthage
   :: TargetPlatform -> InvertedRepositoryMap -> Framework -> Version -> String
-remoteFrameworkPath p r f v =
+remoteFrameworkPathCarthage p r f v =
   remoteCacheDirectory p r f ++ frameworkArchiveName f v
 
 
 
--- | Builds a `String` representing the remote path to a dSYM zip archive
-remoteDsymPath
+-- | Builds a `String` representing the remote path to a dSYM zip archive  for Carthage
+remoteDsymPathCarthage
   :: TargetPlatform -> InvertedRepositoryMap -> Framework -> Version -> String
-remoteDsymPath p r f v = remoteCacheDirectory p r f ++ dSYMArchiveName f v
+remoteDsymPathCarthage p r f v = remoteCacheDirectory p r f ++ dSYMArchiveName f v
 
 
 
--- | Builds a `String` representing the remote path to a bcsymbolmap zip archive
-remoteBcsymbolmapPath
+-- | Builds a `String` representing the remote path to a bcsymbolmap zip archive for Carthage
+remoteBcsymbolmapPathCarthage
   :: DwarfUUID
   -> TargetPlatform
   -> InvertedRepositoryMap
   -> Framework
   -> Version
   -> String
-remoteBcsymbolmapPath d p r f v =
+remoteBcsymbolmapPathCarthage d p r f v =
   remoteCacheDirectory p r f ++ bcsymbolmapArchiveName d v
 
 
@@ -466,10 +466,12 @@ createFrameworkVectorForFrameworkVersion buildTypeConfig frameworkVersion =
                                    frameworkPath p </> _frameworkName framework
                                  )
       , _dSYMPath              = (\p ->
+                                   -- TODO different for PodBuilder
                                    platformBuildPath p
                                      </> (frameworkNameWithFrameworkExtension <> ".dSYM")
                                  )
       , _bcSymbolMapPath       = (\p d ->
+                                   -- TODO Nothing for PodBuilder
                                    platformBuildPath p </> bcsymbolmapNameFrom d
                                  )
       , _versionFileLocalPath  = (\m -> case buildTypeConfig of
@@ -480,10 +482,16 @@ createFrameworkVectorForFrameworkVersion buildTypeConfig frameworkVersion =
                                    PodBuilderConfig _ -> Nothing
                                  )
       , _remoteFrameworkPath   = (\p m ->
-                                   remoteFrameworkPath p m framework version
+                                   -- TODO for PodBuilder use swift version as well as part of the remote path
+                                   remoteFrameworkPathCarthage p m framework version
                                  )
-      , _remoteDsymPath        = (\p m -> remoteDsymPath p m framework version)
-      , _remoteBcSymbolmapPath = (\p m d -> remoteBcsymbolmapPath d
+      , _remoteDsymPath        = (\p m -> 
+                                   -- TODO different for PodBuilder
+                                   remoteDsymPathCarthage p m framework version
+                                 )
+      , _remoteBcSymbolmapPath = (\p m d ->
+                                   -- TODO Nothing for PodBuilder
+                                            remoteBcsymbolmapPathCarthage d
                                                                   p
                                                                   m
                                                                   framework

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -901,15 +901,6 @@ temp_frameworkNameWithFrameworkExtension :: FrameworkVector -> String
 temp_frameworkNameWithFrameworkExtension fVector =
   appendFrameworkExtensionTo (_framework $ _vectorFrameworkVersion fVector)
 
-temp_remoteFrameworkPath
-  :: TargetPlatform
-  -> InvertedRepositoryMap
-  -> FrameworkVector
-  -> CachePrefix
-  -> FilePath
-temp_remoteFrameworkPath platform reverseRomeMap fVector (CachePrefix prefix)
-  = prefix </> _remoteFrameworkPath fVector platform reverseRomeMap
-
 temp_remoteDsymPath
   :: TargetPlatform
   -> InvertedRepositoryMap

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -740,7 +740,7 @@ deleteFrameworkDirectory
   -> Bool -- ^ A flag controlling verbosity
   -> m ()
 deleteFrameworkDirectory buildTypeConfig fVector platform =
-  deleteDirectory $ temp_frameworkDirectory buildTypeConfig platform fVector
+  deleteDirectory $ temp_frameworkPath buildTypeConfig platform fVector
 
 
 
@@ -753,7 +753,7 @@ deleteDSYMDirectory
   -> Bool -- ^ A flag controlling verbosity
   -> m ()
 deleteDSYMDirectory buildTypeConfig fVector platform =
-  deleteDirectory $ temp_dSYMdirectory buildTypeConfig platform fVector
+  deleteDirectory $ temp_dSYMPath buildTypeConfig platform fVector
 
 
 
@@ -849,31 +849,31 @@ fromFile f action = do
 -- TODO These should be moved to field functions on FrameworkVector, so they can be different per build type, but not need to get the build type as parameter
 -- TODO remove "Upload" from function names
 
-temp_frameworkDirectory
+temp_frameworkPath
   :: BuildTypeSpecificConfiguration
   -> TargetPlatform
   -> FrameworkVector
   -> FilePath
-temp_frameworkDirectory buildTypeConfig platform fVector =
-  temp_platformBuildDirectory buildTypeConfig platform fVector
+temp_frameworkPath buildTypeConfig platform fVector =
+  temp_platformBuildPath buildTypeConfig platform fVector
     </> temp_frameworkNameWithFrameworkExtension fVector
 
-temp_dSYMdirectory
+temp_dSYMPath
   :: BuildTypeSpecificConfiguration
   -> TargetPlatform
   -> FrameworkVector
   -> FilePath
-temp_dSYMdirectory buildTypeConfig platform fVector =
-  temp_platformBuildDirectory buildTypeConfig platform fVector
+temp_dSYMPath buildTypeConfig platform fVector =
+  temp_platformBuildPath buildTypeConfig platform fVector
     </> (temp_frameworkNameWithFrameworkExtension fVector <> ".dSYM")
 
-temp_localFrameworkBinaryPath
+temp_frameworkBinaryPath
   :: BuildTypeSpecificConfiguration
   -> TargetPlatform
   -> FrameworkVector
   -> FilePath
-temp_localFrameworkBinaryPath buildTypeConfig platform fVector =
-  temp_frameworkDirectory buildTypeConfig platform fVector
+temp_frameworkBinaryPath buildTypeConfig platform fVector =
+  temp_frameworkPath buildTypeConfig platform fVector
     </> (_frameworkName $ _framework $ _vectorFrameworkVersion fVector)
 
 temp_bcSymbolMapPath
@@ -883,15 +883,15 @@ temp_bcSymbolMapPath
   -> DwarfUUID
   -> FilePath
 temp_bcSymbolMapPath buildTypeConfig platform fVector d =
-  temp_platformBuildDirectory buildTypeConfig platform fVector
+  temp_platformBuildPath buildTypeConfig platform fVector
     </> bcsymbolmapNameFrom d
 
-temp_platformBuildDirectory
+temp_platformBuildPath
   :: BuildTypeSpecificConfiguration
   -> TargetPlatform
   -> FrameworkVector
   -> FilePath
-temp_platformBuildDirectory buildTypeConfig platform fVector =
+temp_platformBuildPath buildTypeConfig platform fVector =
   artifactsBuildDirectoryForPlatform
     buildTypeConfig
     platform
@@ -901,39 +901,39 @@ temp_frameworkNameWithFrameworkExtension :: FrameworkVector -> String
 temp_frameworkNameWithFrameworkExtension fVector =
   appendFrameworkExtensionTo (_framework $ _vectorFrameworkVersion fVector)
 
-temp_remoteFrameworkUploadPath
+temp_remoteFrameworkPath
   :: TargetPlatform
   -> InvertedRepositoryMap
   -> FrameworkVector
   -> CachePrefix
   -> FilePath
-temp_remoteFrameworkUploadPath platform reverseRomeMap fVector (CachePrefix prefix)
+temp_remoteFrameworkPath platform reverseRomeMap fVector (CachePrefix prefix)
   = prefix </> remoteFrameworkPath
     platform
     reverseRomeMap
     (_framework $ _vectorFrameworkVersion fVector)
     (_frameworkVersion $ _vectorFrameworkVersion fVector)
 
-temp_remoteDsymUploadPath
+temp_remoteDsymPath
   :: TargetPlatform
   -> InvertedRepositoryMap
   -> FrameworkVector
   -> CachePrefix
   -> FilePath
-temp_remoteDsymUploadPath platform reverseRomeMap fVector (CachePrefix prefix)
+temp_remoteDsymPath platform reverseRomeMap fVector (CachePrefix prefix)
   = remoteDsymPath platform
                    reverseRomeMap
                    (_framework $ _vectorFrameworkVersion fVector)
                    (_frameworkVersion $ _vectorFrameworkVersion fVector)
 
-temp_remoteBcSymbolmapUploadPath
+temp_remoteBcSymbolmapPath
   :: TargetPlatform
   -> InvertedRepositoryMap
   -> FrameworkVector
   -> CachePrefix
   -> DwarfUUID
   -> FilePath
-temp_remoteBcSymbolmapUploadPath platform reverseRomeMap fVector (CachePrefix prefix) dwarfUUID
+temp_remoteBcSymbolmapPath platform reverseRomeMap fVector (CachePrefix prefix) dwarfUUID
   = prefix </> remoteBcsymbolmapPath
     dwarfUUID
     platform

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -20,7 +20,7 @@ import qualified Data.ByteString.Char8        as BS
 import qualified Data.ByteString.Lazy         as LBS
 import           Data.Carthage.Cartfile
 import           Data.Carthage.TargetPlatform
-import           Data.PodBuilder.PodBuilderInfo
+import           Data.PodBuilder.PodBuilderInfo as PB
 import           Data.Char                    (isNumber)
 import qualified Data.Conduit                 as C (runConduit, (.|))
 import qualified Data.Conduit.Binary          as C (sinkFile, sourceLbs)
@@ -488,8 +488,8 @@ deriveFrameworkNamesAndVersionPodBuilder romeMap =
           }
         , _frameworkVersion = Version
           $   fromMaybe ""
-          $   (hash (restore_version ((restore_info v))))
-          <|> (tag (restore_version ((restore_info v))))
+          $   (hash (PB.version ((PB.restore_info v))))
+          <|> (tag (PB.version ((PB.restore_info v))))
         }
       )
     . M.toList

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -429,27 +429,6 @@ repoNameForFrameworkName reverseRomeMap framework = fromMaybe
 
 
 
--- | Given an `InvertedRepositoryMap` and a list of  `FrameworkVector` produces
--- | a list of __unique__ `ProjectNameAndVersion`s
--- TODO put this method as field into FrameworkVector?
-repoNamesAndVersionForFrameworkVectors
-  :: InvertedRepositoryMap -> [FrameworkVector] -> [ProjectNameAndVersion]
-repoNamesAndVersionForFrameworkVectors reverseRomeMap vectors =
-  repoNamesAndVersionForFrameworkVersions reverseRomeMap
-    $ map _vectorFrameworkVersion vectors
-
-
-
--- | Given an `InvertedRepositoryMap` and a list of  `FrameworkVersion` produces
--- | a list of __unique__ `ProjectNameAndVersion`s
-repoNamesAndVersionForFrameworkVersions
-  :: InvertedRepositoryMap -> [FrameworkVersion] -> [ProjectNameAndVersion]
-repoNamesAndVersionForFrameworkVersions reverseRomeMap versions = nub $ zip
-  (map (repoNameForFrameworkName reverseRomeMap . _framework) versions)
-  (map _frameworkVersion versions)
-
-
-
 -- | Given a `ProjectName` produces the appropriate file name for the corresponding
 -- | Carthage VersionFile
 versionFileNameForProjectName :: ProjectName -> String

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -731,42 +731,29 @@ deleteFile path verbose = do
 
 
 
--- | Deletes a Framework from the Carthage Build folder
+-- | Deletes a Framework from the Build folder
 deleteFrameworkDirectory
   :: MonadIO m
   => BuildTypeSpecificConfiguration
-  -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the Framework to delete
+  -> FrameworkVector -- ^ The `FrameworkVector` identifying the Framework to delete
   -> TargetPlatform -- ^ The `TargetPlatform` to restrict this operation to
   -> Bool -- ^ A flag controlling verbosity
   -> m ()
-deleteFrameworkDirectory buildTypeConfig (FrameworkVersion f _) platform =
-  deleteDirectory frameworkDirectory
- where
-  frameworkNameWithFrameworkExtension = appendFrameworkExtensionTo f
-  platformBuildDirectory =
-    artifactsBuildDirectoryForPlatform buildTypeConfig platform f
-  frameworkDirectory =
-    platformBuildDirectory </> frameworkNameWithFrameworkExtension
+deleteFrameworkDirectory buildTypeConfig fVector platform =
+  deleteDirectory $ temp_frameworkDirectory buildTypeConfig platform fVector
 
 
 
--- | Deletes a dSYM from the Carthage Build folder
+-- | Deletes a dSYM from the Build folder
 deleteDSYMDirectory
   :: MonadIO m
   => BuildTypeSpecificConfiguration
-  -> FrameworkVersion -- ^ The `FrameworkVersion` identifying the dSYM to delete
+  -> FrameworkVector -- ^ The `FrameworkVector` identifying the dSYM to delete
   -> TargetPlatform -- ^ The `TargetPlatform` to restrict this operation to
   -> Bool -- ^ A flag controlling verbosity
   -> m ()
-deleteDSYMDirectory buildTypeConfig (FrameworkVersion f _) platform  =
-  deleteDirectory dSYMDirectory
- where
-  frameworkNameWithFrameworkExtension = appendFrameworkExtensionTo f
-  platformBuildDirectory =
-    artifactsBuildDirectoryForPlatform buildTypeConfig platform f
-  -- FIXME for PodBuilder, dSYMs are NOT contained in platformBuildDirectory, but rather a level above
-  dSYMDirectory =
-    platformBuildDirectory </> frameworkNameWithFrameworkExtension <> ".dSYM"
+deleteDSYMDirectory buildTypeConfig fVector platform =
+  deleteDirectory $ temp_dSYMdirectory buildTypeConfig platform fVector
 
 
 
@@ -860,6 +847,7 @@ fromFile f action = do
 
 -- Temporary FrameworkVector Helper Functions
 -- TODO These should be moved to field functions on FrameworkVector, so they can be different per build type, but not need to get the build type as parameter
+-- TODO remove "Upload" from function names
 
 temp_frameworkDirectory
   :: BuildTypeSpecificConfiguration

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -6,7 +6,9 @@
 module Utils where
 
 import qualified Codec.Archive.Zip            as Zip
-import           Configuration                (artifactsBuildDirectoryForPlatform)
+import           Configuration                ( artifactsBuildDirectoryForPlatform
+                                              , carthageBuildDirectory
+                                              )
 import           Control.Applicative          ( (<|>) )
 import           Control.Arrow                (left)
 import           Control.Exception            as E (try)
@@ -374,6 +376,10 @@ remoteCacheDirectory p r f = repoName </> show p ++ "/"
 -- | `ProjectNameAndVersion`
 remoteVersionFilePath :: ProjectNameAndVersion -> String
 remoteVersionFilePath (projectName, version) =
+  remoteVersionFilePath' projectName version
+
+remoteVersionFilePath' :: ProjectName -> Version -> String
+remoteVersionFilePath' projectName version =
   unProjectName projectName
     </> versionFileNameForProjectNameVersioned projectName version
 
@@ -925,3 +931,28 @@ temp_remoteBcSymbolmapPath platform reverseRomeMap fVector dwarfUUID
     reverseRomeMap
     (_framework $ _vectorFrameworkVersion fVector)
     (_frameworkVersion $ _vectorFrameworkVersion fVector)
+
+
+-- TODO Nothing for PodBuilder
+temp_versionFileLocalPath
+  :: InvertedRepositoryMap -> FrameworkVector -> Maybe FilePath
+temp_versionFileLocalPath reverseRomeMap fVector =
+  Just $ carthageBuildDirectory </> versionFileName
+ where
+  projectName =
+    repoNameForFrameworkName reverseRomeMap
+      $ _framework
+      $ _vectorFrameworkVersion fVector
+  versionFileName = versionFileNameForProjectName projectName
+
+-- TODO Nothing for PodBuilder
+temp_versionFileRemotePath
+  :: InvertedRepositoryMap -> FrameworkVector -> Maybe FilePath
+temp_versionFileRemotePath reverseRomeMap fVector =
+  Just $ remoteVersionFilePath' projectName version
+ where
+  projectName =
+    repoNameForFrameworkName reverseRomeMap
+      $ _framework
+      $ _vectorFrameworkVersion fVector
+  version = (_frameworkVersion $ _vectorFrameworkVersion fVector)

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -905,9 +905,8 @@ temp_remoteDsymPath
   :: TargetPlatform
   -> InvertedRepositoryMap
   -> FrameworkVector
-  -> CachePrefix
   -> FilePath
-temp_remoteDsymPath platform reverseRomeMap fVector (CachePrefix prefix)
+temp_remoteDsymPath platform reverseRomeMap fVector
   = remoteDsymPath platform
                    reverseRomeMap
                    (_framework $ _vectorFrameworkVersion fVector)
@@ -917,11 +916,10 @@ temp_remoteBcSymbolmapPath
   :: TargetPlatform
   -> InvertedRepositoryMap
   -> FrameworkVector
-  -> CachePrefix
   -> DwarfUUID
   -> FilePath
-temp_remoteBcSymbolmapPath platform reverseRomeMap fVector (CachePrefix prefix) dwarfUUID
-  = prefix </> remoteBcsymbolmapPath
+temp_remoteBcSymbolmapPath platform reverseRomeMap fVector dwarfUUID
+  = remoteBcsymbolmapPath
     dwarfUUID
     platform
     reverseRomeMap

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -340,12 +340,27 @@ remoteFrameworkPathCarthage
 remoteFrameworkPathCarthage p r f v =
   remoteCacheDirectory p r f ++ frameworkArchiveName f v
 
+-- | Builds a string representing the remote path to a framework zip archive for PodBuilder.
+remoteFrameworkPathPodBuilder
+  :: TargetPlatform -> InvertedRepositoryMap -> Framework -> Version -> String
+remoteFrameworkPathPodBuilder p r f v =
+  -- TODO correct path
+  remoteCacheDirectory p r f ++ frameworkArchiveName f v
+
 
 
 -- | Builds a `String` representing the remote path to a dSYM zip archive  for Carthage
 remoteDsymPathCarthage
   :: TargetPlatform -> InvertedRepositoryMap -> Framework -> Version -> String
-remoteDsymPathCarthage p r f v = remoteCacheDirectory p r f ++ dSYMArchiveName f v
+remoteDsymPathCarthage p r f v =
+  remoteCacheDirectory p r f ++ dSYMArchiveName f v
+
+-- | Builds a `String` representing the remote path to a dSYM zip archive  for PodBuilder
+remoteDsymPathPodBuilder
+  :: TargetPlatform -> InvertedRepositoryMap -> Framework -> Version -> String
+remoteDsymPathPodBuilder p r f v =
+  -- TODO correct path
+  remoteCacheDirectory p r f ++ dSYMArchiveName f v
 
 
 
@@ -358,6 +373,18 @@ remoteBcsymbolmapPathCarthage
   -> Version
   -> String
 remoteBcsymbolmapPathCarthage d p r f v =
+  remoteCacheDirectory p r f ++ bcsymbolmapArchiveName d v
+
+-- | Builds a `String` representing the remote path to a bcsymbolmap zip archive for PodBuilder
+remoteBcsymbolmapPathPodBuilder
+  :: DwarfUUID
+  -> TargetPlatform
+  -> InvertedRepositoryMap
+  -> Framework
+  -> Version
+  -> String
+remoteBcsymbolmapPathPodBuilder d p r f v =
+  -- TODO correct path
   remoteCacheDirectory p r f ++ bcsymbolmapArchiveName d v
 
 
@@ -465,14 +492,21 @@ createFrameworkVectorForFrameworkVersion buildTypeConfig frameworkVersion =
       , _frameworkBinaryPath   = (\p ->
                                    frameworkPath p </> _frameworkName framework
                                  )
-      , _dSYMPath              = (\p ->
-                                   -- TODO different for PodBuilder
-                                   platformBuildPath p
-                                     </> (frameworkNameWithFrameworkExtension <> ".dSYM")
+      , _dSYMPath              = (\p -> case buildTypeConfig of
+                                   CarthageConfig _ ->
+                                     platformBuildPath p
+                                       </> (frameworkNameWithFrameworkExtension <> ".dSYM")
+                                   PodBuilderConfig _ ->
+                                     -- TODO correct path
+                                     platformBuildPath p
+                                       </> (frameworkNameWithFrameworkExtension <> ".dSYM")
                                  )
-      , _bcSymbolMapPath       = (\p d ->
-                                   -- TODO Nothing for PodBuilder
-                                   platformBuildPath p </> bcsymbolmapNameFrom d
+      , _bcSymbolMapPath       = (\p d -> case buildTypeConfig of
+                                   CarthageConfig _ ->
+                                     platformBuildPath p </> bcsymbolmapNameFrom d
+                                   PodBuilderConfig _ ->
+                                     -- TODO correct path
+                                     platformBuildPath p </> bcsymbolmapNameFrom d
                                  )
       , _versionFileLocalPath  = (\m -> case buildTypeConfig of
                                    CarthageConfig _ ->
@@ -481,21 +515,37 @@ createFrameworkVectorForFrameworkVersion buildTypeConfig frameworkVersion =
                                        </> versionFileName m
                                    PodBuilderConfig _ -> Nothing
                                  )
-      , _remoteFrameworkPath   = (\p m ->
-                                   -- TODO for PodBuilder use swift version as well as part of the remote path
-                                   remoteFrameworkPathCarthage p m framework version
+      , _remoteFrameworkPath   = (\p m -> case buildTypeConfig of
+                                   CarthageConfig _ ->
+                                     remoteFrameworkPathCarthage p
+                                                                 m
+                                                                 framework
+                                                                 version
+                                   PodBuilderConfig _ ->
+                                     remoteFrameworkPathPodBuilder p
+                                                                   m
+                                                                   framework
+                                                                   version
                                  )
-      , _remoteDsymPath        = (\p m -> 
-                                   -- TODO different for PodBuilder
-                                   remoteDsymPathCarthage p m framework version
+      , _remoteDsymPath        = (\p m -> case buildTypeConfig of
+                                   CarthageConfig _ ->
+                                     remoteDsymPathCarthage p m framework version
+                                   PodBuilderConfig _ ->
+                                     remoteDsymPathPodBuilder p m framework version
                                  )
-      , _remoteBcSymbolmapPath = (\p m d ->
-                                   -- TODO Nothing for PodBuilder
-                                            remoteBcsymbolmapPathCarthage d
-                                                                  p
-                                                                  m
-                                                                  framework
-                                                                  version
+      , _remoteBcSymbolmapPath = (\p m d -> case buildTypeConfig of
+                                   CarthageConfig _ ->
+                                     remoteBcsymbolmapPathCarthage d
+                                                                   p
+                                                                   m
+                                                                   framework
+                                                                   version
+                                   PodBuilderConfig _ ->
+                                     remoteBcsymbolmapPathPodBuilder d
+                                                                     p
+                                                                     m
+                                                                     framework
+                                                                     version
                                  )
       , _versionFileRemotePath = (\m -> case buildTypeConfig of
                                    CarthageConfig _ ->

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -271,7 +271,7 @@ filterByFrameworkEqualTo versions f =
 filterOutFrameworksAndVersionsIfNotIn
   :: [FrameworkVector] -> [Framework] -> [FrameworkVector]
 filterOutFrameworksAndVersionsIfNotIn vectors frameworks = do
-  vec@(FrameworkVector ver@(FrameworkVersion f@(Framework n t ps) v) rfp) <-
+  vec@(FrameworkVector ver@(FrameworkVersion f@(Framework n t ps) v) paths) <-
     vectors -- For each version
   let filtered =
         (\(Framework nF tF psF) -> nF == n && tF == t) `filter` frameworks -- filter the frameworks to exclude based on name and type, not on the platforms
@@ -281,7 +281,7 @@ filterOutFrameworksAndVersionsIfNotIn vectors frameworks = do
       let op =
             f `removePlatformsIn` nub (concatMap _frameworkPlatforms filtered)
       guard (not . null $ _frameworkPlatforms op) -- if the entry completely filters out the FrameworkVector then remove it
-      return $ FrameworkVector (FrameworkVersion op v) rfp -- if it doesn't, then remove from f the platforms that appear in the filter above.
+      return $ FrameworkVector (FrameworkVersion op v) paths -- if it doesn't, then remove from f the platforms that appear in the filter above.
  where
   removePlatformsIn :: Framework -> [TargetPlatform] -> Framework
   removePlatformsIn (Framework n t ps) rPs =
@@ -471,12 +471,14 @@ tempWrapFrameworkVersionInFrameworkVector
 tempWrapFrameworkVersionInFrameworkVector buildTypeConfig frameworkVersion =
   FrameworkVector
     { _vectorFrameworkVersion = frameworkVersion
-    , _remoteFrameworkPath    = (\p m -> remoteFrameworkPath
-                                  p
-                                  m
-                                  (_framework frameworkVersion)
-                                  (_frameworkVersion frameworkVersion)
-                                )
+    , _vectorPaths            = FrameworkVectorPaths
+      { _remoteFrameworkPath = (\p m -> remoteFrameworkPath
+                                 p
+                                 m
+                                 (_framework frameworkVersion)
+                                 (_frameworkVersion frameworkVersion)
+                               )
+      }
     }
 
 -- | Given a `RepositoryMap` and either a list of `CartfileEntry` or a `PodBuilderInfo` creates a list of

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -908,11 +908,7 @@ temp_remoteFrameworkPath
   -> CachePrefix
   -> FilePath
 temp_remoteFrameworkPath platform reverseRomeMap fVector (CachePrefix prefix)
-  = prefix </> remoteFrameworkPath
-    platform
-    reverseRomeMap
-    (_framework $ _vectorFrameworkVersion fVector)
-    (_frameworkVersion $ _vectorFrameworkVersion fVector)
+  = prefix </> _remoteFrameworkPath fVector platform reverseRomeMap
 
 temp_remoteDsymPath
   :: TargetPlatform

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -530,7 +530,6 @@ deriveFrameworkVectors
 deriveFrameworkVectors romeMap buildTypeConfig =
   map (tempWrapFrameworkVersionInFrameworkVector buildTypeConfig)
     $ deriveFrameworkNamesAndVersion romeMap buildTypeConfig
-  -- TODO add fields for paths to FrameworkVector and create them here
 
 -- | Given a `RepositoryMap` and either a list of `CartfileEntry` or a `PodBuilderInfo` creates a list of
 -- | `FrameworkVersion`s. See `deriveFrameworkNameAndVersion` for details.
@@ -763,12 +762,11 @@ deleteFile path verbose = do
 -- | Deletes a Framework from the Build folder
 deleteFrameworkDirectory
   :: MonadIO m
-  => BuildTypeSpecificConfiguration
-  -> FrameworkVector -- ^ The `FrameworkVector` identifying the Framework to delete
+  => FrameworkVector -- ^ The `FrameworkVector` identifying the Framework to delete
   -> TargetPlatform -- ^ The `TargetPlatform` to restrict this operation to
   -> Bool -- ^ A flag controlling verbosity
   -> m ()
-deleteFrameworkDirectory buildTypeConfig fVector platform =
+deleteFrameworkDirectory fVector platform =
   deleteDirectory $ _frameworkPath (_vectorPaths fVector) platform
 
 
@@ -776,12 +774,11 @@ deleteFrameworkDirectory buildTypeConfig fVector platform =
 -- | Deletes a dSYM from the Build folder
 deleteDSYMDirectory
   :: MonadIO m
-  => BuildTypeSpecificConfiguration
-  -> FrameworkVector -- ^ The `FrameworkVector` identifying the dSYM to delete
+  => FrameworkVector -- ^ The `FrameworkVector` identifying the dSYM to delete
   -> TargetPlatform -- ^ The `TargetPlatform` to restrict this operation to
   -> Bool -- ^ A flag controlling verbosity
   -> m ()
-deleteDSYMDirectory buildTypeConfig fVector platform =
+deleteDSYMDirectory fVector platform =
   deleteDirectory $ _dSYMPath (_vectorPaths fVector) platform
 
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -22,7 +22,7 @@ nonEmptyString :: Gen String
 nonEmptyString = listOf1 arbitrary
 
 instance Arbitrary FrameworkVector where
-  arbitrary = liftM (\fv -> FrameworkVector{_vectorFrameworkVersion = fv, _vectorPaths = FrameworkVectorPaths (\x y -> "")}) arbitrary
+  arbitrary = liftM (\fv -> FrameworkVector{_vectorFrameworkVersion = fv, _vectorPaths = FrameworkVectorPaths (\x -> "") (\x -> "") (\x -> "") (\x y -> "") (\x -> Just "") (\x y -> "") (\x y -> "") (\x y z -> "") (\x -> Just "")}) arbitrary
 
 instance Arbitrary FrameworkVersion where
   arbitrary = liftM2 FrameworkVersion arbitrary arbitrary
@@ -75,7 +75,7 @@ prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut vs fws =
   null
     $ (   FrameworkVector
       <$> (FrameworkVersion <$> fws <*> vs)
-      <*> [FrameworkVectorPaths (\x y -> "")]
+      <*> [FrameworkVectorPaths (\x -> "") (\x -> "") (\x -> "") (\x y -> "") (\x -> Just "") (\x y -> "") (\x y -> "") (\x y z -> "") (\x -> Just "")]
       )
     `filterOutFrameworksAndVersionsIfNotIn` fws
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -22,7 +22,7 @@ nonEmptyString :: Gen String
 nonEmptyString = listOf1 arbitrary
 
 instance Arbitrary FrameworkVector where
-  arbitrary = liftM FrameworkVector arbitrary
+  arbitrary = liftM (\fv -> FrameworkVector{_vectorFrameworkVersion = fv, _remoteFrameworkPath = (\x y -> "")}) arbitrary
 
 instance Arbitrary FrameworkVersion where
   arbitrary = liftM2 FrameworkVersion arbitrary arbitrary
@@ -56,10 +56,13 @@ prop_filterByNameEqualTo_model ls n =
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent
   :: [FrameworkVector] -> [Framework] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent ls ns =
-  filterOutFrameworksAndVersionsIfNotIn ls ns
-    == filterOutFrameworksAndVersionsIfNotIn
-         (filterOutFrameworksAndVersionsIfNotIn ls ns)
-         ns
+  map _vectorFrameworkVersion (filterOutFrameworksAndVersionsIfNotIn ls ns)
+    == map
+         _vectorFrameworkVersion
+         (filterOutFrameworksAndVersionsIfNotIn
+           (filterOutFrameworksAndVersionsIfNotIn ls ns)
+           ns
+         )
 
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller
   :: [FrameworkVector] -> [Framework] -> Bool
@@ -70,7 +73,7 @@ prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut
   :: [Version] -> [Framework] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut vs fws =
   null
-    $ (FrameworkVector <$> (FrameworkVersion <$> fws <*> vs))
+    $ (FrameworkVector <$> (FrameworkVersion <$> fws <*> vs) <*> [(\x y -> "")])
     `filterOutFrameworksAndVersionsIfNotIn` fws
 
 prop_split_length :: Char -> String -> Property

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -22,7 +22,7 @@ nonEmptyString :: Gen String
 nonEmptyString = listOf1 arbitrary
 
 instance Arbitrary FrameworkVector where
-  arbitrary = liftM (\fv -> FrameworkVector{_vectorFrameworkVersion = fv, _remoteFrameworkPath = (\x y -> "")}) arbitrary
+  arbitrary = liftM (\fv -> FrameworkVector{_vectorFrameworkVersion = fv, _vectorPaths = FrameworkVectorPaths (\x y -> "")}) arbitrary
 
 instance Arbitrary FrameworkVersion where
   arbitrary = liftM2 FrameworkVersion arbitrary arbitrary
@@ -73,7 +73,10 @@ prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut
   :: [Version] -> [Framework] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut vs fws =
   null
-    $ (FrameworkVector <$> (FrameworkVersion <$> fws <*> vs) <*> [(\x y -> "")])
+    $ (   FrameworkVector
+      <$> (FrameworkVersion <$> fws <*> vs)
+      <*> [FrameworkVectorPaths (\x y -> "")]
+      )
     `filterOutFrameworksAndVersionsIfNotIn` fws
 
 prop_split_length :: Char -> String -> Property

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -21,6 +21,9 @@ import           Test.QuickCheck
 nonEmptyString :: Gen String
 nonEmptyString = listOf1 arbitrary
 
+instance Arbitrary FrameworkVector where
+  arbitrary = liftM FrameworkVector arbitrary
+
 instance Arbitrary FrameworkVersion where
   arbitrary = liftM2 FrameworkVersion arbitrary arbitrary
 
@@ -51,7 +54,7 @@ prop_filterByNameEqualTo_model ls n =
     == filter (== n) (map _framework ls)
 
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent
-  :: [FrameworkVersion] -> [Framework] -> Bool
+  :: [FrameworkVector] -> [Framework] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent ls ns =
   filterOutFrameworksAndVersionsIfNotIn ls ns
     == filterOutFrameworksAndVersionsIfNotIn
@@ -59,14 +62,16 @@ prop_filterOutFrameworkNamesAndVersionsIfNotIn_idempotent ls ns =
          ns
 
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller
-  :: [FrameworkVersion] -> [Framework] -> Bool
+  :: [FrameworkVector] -> [Framework] -> Bool
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_smaller ls ns =
   length (filterOutFrameworksAndVersionsIfNotIn ls ns) <= length ls
 
 prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut
   :: [Version] -> [Framework] -> Bool
-prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut vs fws = 
-  null $ (FrameworkVersion <$> fws <*> vs) `filterOutFrameworksAndVersionsIfNotIn` fws
+prop_filterOutFrameworkNamesAndVersionsIfNotIn_filterAllOut vs fws =
+  null
+    $ (FrameworkVector <$> (FrameworkVersion <$> fws <*> vs))
+    `filterOutFrameworksAndVersionsIfNotIn` fws
 
 prop_split_length :: Char -> String -> Property
 prop_split_length sep ls =


### PR DESCRIPTION
As discussed in https://github.com/blender/Rome/issues/155, support for [PodBuilder](https://github.com/Subito-it/PodBuilder) would be nice additionally to Carthage.

⚠️ Not finished, this is work in progress.

- ~Parse and analyze the Podfile.restore file to find out which framework versions the project depends on~
- ~Parse and analyze the PodBuilder.podspec file to find out which frameworks would need to be generated~
- ~Parse the PodBuilder.plist files and use them instead of Carthage version files~
- [x] Parse the `pod_builder info` json output from a file
- [ ] Receive `podbuilder info` output via STDIN or as a parameter (a temporary file would not be so nice)
- [x] Add and parse a configuration option flag which tells Rome that it needs to deal with a PodBuilder project
- [ ] (optional) put the configuration option to Romefile
- [x] Add and parse a configuration option flag for passing the compiler version, since `pod_builder info` contains the `swift_version` for each built Swift framework, and we need to compare it to the expected one, and use it as part of the cache key
- [x] Extract functionality common to Carthage and PodBuilder, and execute different code paths based on configuration option
- [ ] Use the PodBuilder folder structure instead of the one of Carthage/Build
- [ ] Since CocoaPods/Rome and therefore PodBuilder only seems to support one platform at a time, ignore TargetPlatform, or set it to some placeholder
- [ ] Update Readme